### PR TITLE
Fixed handling of end dates when creating new services

### DIFF
--- a/app/Services/DataPersistence/ServicePersistenceService.php
+++ b/app/Services/DataPersistence/ServicePersistenceService.php
@@ -6,12 +6,12 @@ use App\Models\File;
 use App\Models\Model;
 use App\Models\Service;
 use App\Models\Taxonomy;
-use Carbon\CarbonImmutable;
-use App\Support\MissingValue;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Date;
-use Illuminate\Foundation\Http\FormRequest;
 use App\Models\UpdateRequest as UpdateRequestModel;
+use App\Support\MissingValue;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\DB;
 
 class ServicePersistenceService implements DataPersistenceService
 {

--- a/app/Services/DataPersistence/ServicePersistenceService.php
+++ b/app/Services/DataPersistence/ServicePersistenceService.php
@@ -6,11 +6,12 @@ use App\Models\File;
 use App\Models\Model;
 use App\Models\Service;
 use App\Models\Taxonomy;
-use App\Models\UpdateRequest as UpdateRequestModel;
+use Carbon\CarbonImmutable;
 use App\Support\MissingValue;
-use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Foundation\Http\FormRequest;
+use App\Models\UpdateRequest as UpdateRequestModel;
 
 class ServicePersistenceService implements DataPersistenceService
 {
@@ -137,7 +138,9 @@ class ServicePersistenceService implements DataPersistenceService
                 'referral_url' => $request->referral_url,
                 'logo_file_id' => $request->logo_file_id,
                 'last_modified_at' => Date::now(),
-                'ends_at' => $request->ends_at,
+                'ends_at' => $request->filled('ends_at')
+                    ? Date::createFromFormat(CarbonImmutable::ISO8601, $request->ends_at)
+                    : null,
             ];
 
             foreach ($request->input('eligibility_types.custom', []) as $customEligibilityType => $value) {

--- a/tests/Feature/ServicesTest.php
+++ b/tests/Feature/ServicesTest.php
@@ -2,33 +2,34 @@
 
 namespace Tests\Feature;
 
-use App\Events\EndpointHit;
-use App\Models\Audit;
+use Carbon\Carbon;
+use Tests\TestCase;
 use App\Models\File;
-use App\Models\HolidayOpeningHour;
-use App\Models\Organisation;
-use App\Models\RegularOpeningHour;
 use App\Models\Role;
-use App\Models\Service;
-use App\Models\ServiceLocation;
-use App\Models\ServiceRefreshToken;
-use App\Models\ServiceTaxonomy;
-use App\Models\SocialMedia;
-use App\Models\Taxonomy;
-use App\Models\UpdateRequest;
 use App\Models\User;
+use App\Models\Audit;
+use App\Models\Service;
+use App\Models\Taxonomy;
 use App\Models\UserRole;
+use App\Events\EndpointHit;
+use App\Models\SocialMedia;
 use Carbon\CarbonImmutable;
 use Faker\Factory as Faker;
-use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Http\Response;
-use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
+use App\Models\Organisation;
+use App\Models\UpdateRequest;
+use Illuminate\Http\Response;
+use Laravel\Passport\Passport;
+use App\Models\ServiceLocation;
+use App\Models\ServiceTaxonomy;
+use Illuminate\Http\UploadedFile;
+use App\Models\HolidayOpeningHour;
+use App\Models\RegularOpeningHour;
+use App\Models\ServiceRefreshToken;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
-use Laravel\Passport\Passport;
-use Tests\TestCase;
+use Illuminate\Database\Eloquent\Collection;
 
 class ServicesTest extends TestCase
 {
@@ -434,7 +435,7 @@ class ServicesTest extends TestCase
             'referral_button_text' => null,
             'referral_email' => null,
             'referral_url' => null,
-            'ends_at' => null,
+            'ends_at' => Carbon::now()->addMonths(6)->toDateString() . 'T00:00:00+0000',
             'useful_infos' => [
                 [
                     'title' => 'Did you know?',
@@ -498,7 +499,7 @@ class ServicesTest extends TestCase
             'referral_button_text' => null,
             'referral_email' => null,
             'referral_url' => null,
-            'ends_at' => null,
+            'ends_at' => Carbon::now()->addMonths(6)->toDateString() . 'T00:00:00+0000',
             'useful_infos' => [
                 [
                     'title' => 'Did you know?',


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/2336/auto-disable-services-after-a-specific-date

- Fixed handling of ISO8601 end dates when creating service

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
