### PR TITLE
Stuartlaverick/sc 2338/data freshness

### DIFF
--- a/app/Docs/OpenApi.php
+++ b/app/Docs/OpenApi.php
@@ -81,6 +81,7 @@ class OpenApi extends BaseOpenApi implements Responsable
                 Paths\ServiceLocations\ServiceLocationsImagePath::create(),
                 Paths\Services\ServicesRootPath::create(),
                 Paths\Services\ServicesIndexPath::create(),
+                Paths\Services\ServicesDisableStalePath::create(),
                 Paths\Services\ServicesNestedPath::create(),
                 Paths\Services\ServicesRefreshPath::create(),
                 Paths\Services\ServicesRelatedPath::create(),

--- a/app/Docs/Operations/Services/DisableStaleServiceOperation.php
+++ b/app/Docs/Operations/Services/DisableStaleServiceOperation.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Docs\Operations\Services;
+
+use App\Docs\Schemas\Service\DisableStaleServiceSchema;
+use App\Docs\Tags\ServicesTag;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\BaseObject;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\MediaType;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Operation;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\RequestBody;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Response;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Schema;
+
+class DisableStaleServiceOperation extends Operation
+{
+    /**
+     * @param string|null $objectId
+     * @throws \GoldSpecDigital\ObjectOrientedOAS\Exceptions\InvalidArgumentException
+     * @return static
+     */
+    public static function create(string $objectId = null): BaseObject
+    {
+        return parent::create($objectId)
+            ->action(static::ACTION_PUT)
+            ->tags(ServicesTag::create())
+            ->summary('Disables stale services which haven\'t been updated')
+            ->description('**Permission:** `Super Admin`')
+            ->noSecurity()
+            ->requestBody(
+                RequestBody::create()->content(
+                    MediaType::json()->schema(DisableStaleServiceSchema::create())
+                )
+            )
+            ->responses(
+                Response::ok()->content(
+                    MediaType::json()->schema(
+                        Schema::object()->properties(
+                            Schema::string('message')->example('Stale services disabled')
+                        )
+                    )
+                )
+            );
+    }
+}

--- a/app/Docs/Paths/Services/ServicesDisableStalePath.php
+++ b/app/Docs/Paths/Services/ServicesDisableStalePath.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Docs\Paths\Services;
+
+use App\Docs\Operations\Services\DisableStaleServiceOperation;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\BaseObject;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\PathItem;
+
+class ServicesDisableStalePath extends PathItem
+{
+    /**
+     * @param string|null $objectId
+     * @throws \GoldSpecDigital\ObjectOrientedOAS\Exceptions\InvalidArgumentException
+     * @return static
+     */
+    public static function create(string $objectId = null): BaseObject
+    {
+        return parent::create($objectId)
+            ->route('/services/disable-stale')
+            ->operations(
+                DisableStaleServiceOperation::create()
+            );
+    }
+}

--- a/app/Docs/Schemas/Service/DisableStaleServiceSchema.php
+++ b/app/Docs/Schemas/Service/DisableStaleServiceSchema.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Docs\Schemas\Service;
+
+use GoldSpecDigital\ObjectOrientedOAS\Objects\BaseObject;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Schema;
+
+class DisableStaleServiceSchema extends Schema
+{
+    /**
+     * @param string|null $objectId
+     * @throws \GoldSpecDigital\ObjectOrientedOAS\Exceptions\InvalidArgumentException
+     * @return static
+     */
+    public static function create(string $objectId = null): BaseObject
+    {
+        return parent::create($objectId)
+            ->type(static::TYPE_OBJECT)
+            ->required('last_modified_at')
+            ->properties(
+                Schema::string('last_modified_at')
+                    ->format(Schema::FORMAT_DATE)
+                    ->description('The date to specify when services last updated before should be disabled')
+            );
+    }
+}

--- a/app/Docs/Schemas/Service/RefreshServiceSchema.php
+++ b/app/Docs/Schemas/Service/RefreshServiceSchema.php
@@ -20,7 +20,7 @@ class RefreshServiceSchema extends Schema
             ->properties(
                 Schema::string('token')
                     ->format(Schema::FORMAT_UUID)
-                    ->description('A unique one-time token needed to invoke the refresh')
+                    ->description('A unique one-time token needed to invoke the refresh (not required if a service admin)')
             );
     }
 }

--- a/app/Http/Controllers/Core/V1/Service/DisableStaleController.php
+++ b/app/Http/Controllers/Core/V1/Service/DisableStaleController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Core\V1\Service;
+
+use App\Events\EndpointHit;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Service\DisableStale\UpdateRequest;
+use App\Models\Service;
+use Illuminate\Support\Facades\DB;
+
+class DisableStaleController extends Controller
+{
+    /**
+     * DisableStaleController constructor.
+     */
+    public function __construct()
+    {
+        $this->middleware('auth:api');
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param \App\Http\Requests\Service\DisableStale\UpdateRequest $request
+     * @param \App\Models\Service $service
+     * @return \Illuminate\Http\Response
+     */
+    public function __invoke(UpdateRequest $request, Service $service)
+    {
+        return DB::transaction(function () use ($request, $service) {
+            Service::query()
+                ->where('last_modified_at', '<', $request->last_modified_at)
+                ->update(['status' => Service::STATUS_INACTIVE]);
+
+            event(EndpointHit::onUpdate($request, "Disabled stale services from [{$request->last_modified_at}]"));
+
+            return response()->json([
+                'message' => 'Stale services have been disabled.',
+            ]);
+        });
+    }
+}

--- a/app/Http/Controllers/Core/V1/Service/RefreshController.php
+++ b/app/Http/Controllers/Core/V1/Service/RefreshController.php
@@ -27,7 +27,9 @@ class RefreshController extends Controller
             $service->update(['last_modified_at' => Date::now()]);
 
             // Delete the token used.
-            ServiceRefreshToken::query()->findOrFail($request->token)->delete();
+            if ($request->has('token')) {
+                ServiceRefreshToken::query()->findOrFail($request->token)->delete();
+            }
 
             event(EndpointHit::onUpdate($request, "Refreshed service [{$service->id}]", $service));
 

--- a/app/Http/Controllers/Core/V1/ServiceController.php
+++ b/app/Http/Controllers/Core/V1/ServiceController.php
@@ -70,6 +70,7 @@ class ServiceController extends Controller
                 Sort::custom('organisation_name', OrganisationNameSort::class),
                 'status',
                 'referral_method',
+                'last_modified_at',
             ])
             ->defaultSort('name')
             ->paginate(per_page($request->per_page));

--- a/app/Http/Requests/Service/DisableStale/UpdateRequest.php
+++ b/app/Http/Requests/Service/DisableStale/UpdateRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests\Service\DisableStale;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        if ($this->user()->isSuperAdmin()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'last_modified_at' => ['required', 'date_format:Y-m-d'],
+        ];
+    }
+}

--- a/app/Http/Requests/Service/Refresh/UpdateRequest.php
+++ b/app/Http/Requests/Service/Refresh/UpdateRequest.php
@@ -23,8 +23,12 @@ class UpdateRequest extends FormRequest
      */
     public function rules()
     {
+        if (optional($this->user('api'))->isServiceAdmin($this->service)) {
+            return [];
+        }
+
         return [
-            'token' => ['exists:service_refresh_tokens,id'],
+            'token' => ['required', 'exists:service_refresh_tokens,id'],
         ];
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -147,6 +147,8 @@ Route::prefix('/core/v1')
 
             // Services.
             Route::match(['GET', 'POST'], '/services/index', 'ServiceController@index');
+            Route::put('/services/disable-stale', 'Service\\DisableStaleController')
+                ->name('services.disable-stale');
             Route::apiResource('/services', 'ServiceController');
             Route::put('/services/{service}/refresh', 'Service\\RefreshController')
                 ->name('services.refresh');

--- a/tests/Feature/ServicesTest.php
+++ b/tests/Feature/ServicesTest.php
@@ -280,6 +280,22 @@ class ServicesTest extends TestCase
         $this->assertEquals($serviceTwo->organisation_id, $data['data'][0]['organisation_id']);
     }
 
+    public function test_guest_can_sort_by_last_modified_at()
+    {
+        $serviceOne = factory(Service::class)->create([
+            'last_modified_at' => '2020-01-01 13:00:00'
+        ]);
+        $serviceTwo = factory(Service::class)->create([
+            'last_modified_at' => '2020-01-01 20:00:00'
+        ]);
+
+        $response = $this->json('GET', '/core/v1/services?sort=-last_modified_at');
+        $data = $this->getResponseContent($response);
+
+        $this->assertEquals($serviceOne->organisation_id, $data['data'][1]['organisation_id']);
+        $this->assertEquals($serviceTwo->organisation_id, $data['data'][0]['organisation_id']);
+    }
+
     /*
      * Create a service.
      */


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/2338/data-freshness

- Sort services by last modified at https://github.com/the-leeds-repo/api/pull/24
- Service admins can refresh service without token https://github.com/the-leeds-repo/api/pull/32/
- Bulk disable services https://github.com/the-leeds-repo/api/pull/33/

### Development checklist

- [x] Changes have been made to the API?
  - [x] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
