### PR TITLE
Added additional tests for global admin permissions

### DIFF
--- a/tests/Feature/ServicesTest.php
+++ b/tests/Feature/ServicesTest.php
@@ -1295,7 +1295,7 @@ class ServicesTest extends TestCase
             'referral_button_text' => null,
             'referral_email' => null,
             'referral_url' => null,
-            'cqc_location_id' => $this->faker->numerify('#-#########'),
+            'ends_at' => null,
             'useful_infos' => [
                 [
                     'title' => 'Did you know?',
@@ -1309,13 +1309,8 @@ class ServicesTest extends TestCase
                     'order' => 1,
                 ],
             ],
-            'tags' => [],
             'gallery_items' => [],
             'category_taxonomies' => [],
-            'eligibility_types' => [
-                'custom' => [],
-                'taxonomies' => [],
-            ],
         ];
 
         //When they create a service
@@ -1389,7 +1384,7 @@ class ServicesTest extends TestCase
             'referral_button_text' => null,
             'referral_email' => null,
             'referral_url' => null,
-            'cqc_location_id' => $this->faker->numerify('#-#########'),
+            'ends_at' => null,
             'useful_infos' => [
                 [
                     'title' => 'Did you know?',
@@ -1403,14 +1398,9 @@ class ServicesTest extends TestCase
                     'order' => 1,
                 ],
             ],
-            'tags' => [],
             'gallery_items' => [],
             'category_taxonomies' => [
                 $taxonomy->id,
-            ],
-            'eligibility_types' => [
-                'custom' => [],
-                'taxonomies' => [],
             ],
         ];
 


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/2431/added-additional-tests-for-global-admin-permissions

- Cherry pick https://github.com/LondonBoroughSutton/suttoninformationhub-api/pull/28/commits/e115b970c2745e606aec3050e9ee1eeedb5306bd

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
