### PR TITLE
Service search includes service_locations in returned objects

### DIFF
--- a/app/Search/ElasticSearch/ServiceEloquentMapper.php
+++ b/app/Search/ElasticSearch/ServiceEloquentMapper.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare (strict_types=1);
 
 namespace App\Search\ElasticSearch;
 
@@ -23,6 +23,8 @@ class ServiceEloquentMapper implements EloquentMapper
     {
         $page = page($page);
         $perPage = per_page($perPage);
+
+        $esQuery->load(['serviceLocations'], Service::class);
 
         $queryRequest = $esQuery->buildSearchRequest()->toArray();
 
@@ -58,7 +60,7 @@ class ServiceEloquentMapper implements EloquentMapper
 
     protected function orderServicesByLocation(array $queryRequest, Collection $services): Collection
     {
-        $locations = array_filter($queryRequest['body']['sort']?? [], function ($key) {
+        $locations = array_filter($queryRequest['body']['sort'] ?? [], function ($key) {
             return $key === '_geo_distance';
         }, ARRAY_FILTER_USE_KEY);
 

--- a/tests/Feature/Search/ServiceTest.php
+++ b/tests/Feature/Search/ServiceTest.php
@@ -34,11 +34,73 @@ class ServiceTest extends TestCase implements UsesElasticsearch
 
     public function test_guest_can_search()
     {
+        Service::factory()->create(['name' => 'Thisisatest']);
+
+        sleep(1);
+
         $response = $this->json('POST', '/core/v1/search', [
-            'query' => 'test',
+            'query' => 'Thisisatest',
         ]);
 
         $response->assertStatus(Response::HTTP_OK);
+
+        $response->assertJsonStructure([
+            'data' => [
+                [
+                    "id",
+                    "organisation_id",
+                    "has_logo",
+                    "slug",
+                    "name",
+                    "type",
+                    "status",
+                    "intro",
+                    "description",
+                    "wait_time",
+                    "is_free",
+                    "fees_text",
+                    "fees_url",
+                    "testimonial",
+                    "video_embed",
+                    "url",
+                    "contact_name",
+                    "contact_phone",
+                    "contact_email",
+                    "show_referral_disclaimer",
+                    "referral_method",
+                    "referral_button_text",
+                    "referral_email",
+                    "referral_url",
+                    "useful_infos",
+                    "offerings",
+                    "gallery_items",
+                    "tags",
+                    "category_taxonomies",
+                    "eligibility_types" => [
+                        "custom" => [
+                            "age_group",
+                            "disability",
+                            "ethnicity",
+                            "gender",
+                            "income",
+                            "language",
+                            "housing",
+                            "other",
+                        ],
+                        "taxonomies",
+                    ],
+                    "score",
+                    "ends_at",
+                    "last_modified_at",
+                    "created_at",
+                    "updated_at",
+                    "service_locations",
+                    "cqc_location_id",
+                ],
+            ],
+            'links',
+            'meta',
+        ]);
     }
 
     public function test_query_matches_service_name()
@@ -1108,7 +1170,7 @@ class ServiceTest extends TestCase implements UsesElasticsearch
         $response = $this->json('POST', '/core/v1/search', [
             'query' => 'Thisisatest',
             'eligibilities' => [
-                '12 - 15 years', ],
+                '12 - 15 years'],
         ]);
 
         $response->assertStatus(Response::HTTP_OK);


### PR DESCRIPTION
### Summary
- The service objects returned from a search did not include the `service_locations` property which caused the frontend code to error as it expected this property
- Relationship `serviceLocations` is lazily loaded during the search request and included in the returned objects

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
