### PR TITLE
Sutton sc 2754 create a new content admin user role

### DIFF
--- a/app/Http/Controllers/Core/V1/UserController.php
+++ b/app/Http/Controllers/Core/V1/UserController.php
@@ -125,6 +125,9 @@ class UserController extends Controller
                     case Role::NAME_ORGANISATION_ADMIN:
                         $user->makeOrganisationAdmin($organisation);
                         break;
+                    case Role::NAME_CONTENT_ADMIN:
+                        $user->makeContentAdmin();
+                        break;
                     case Role::NAME_GLOBAL_ADMIN:
                         $user->makeGlobalAdmin();
                         break;

--- a/app/Http/Controllers/Core/V1/UserController.php
+++ b/app/Http/Controllers/Core/V1/UserController.php
@@ -229,6 +229,9 @@ class UserController extends Controller
                         case Role::NAME_ORGANISATION_ADMIN:
                             $user->revokeOrganisationAdmin($organisation);
                             break;
+                        case Role::NAME_CONTENT_ADMIN:
+                            $user->revokeContentAdmin();
+                            break;
                         case Role::NAME_GLOBAL_ADMIN:
                             $user->revokeGlobalAdmin();
                             break;
@@ -255,6 +258,9 @@ class UserController extends Controller
                         break;
                     case Role::NAME_ORGANISATION_ADMIN:
                         $user->makeOrganisationAdmin($organisation);
+                        break;
+                    case Role::NAME_CONTENT_ADMIN:
+                        $user->makeContentAdmin();
                         break;
                     case Role::NAME_GLOBAL_ADMIN:
                         $user->makeGlobalAdmin();

--- a/app/Http/Requests/Page/DestroyRequest.php
+++ b/app/Http/Requests/Page/DestroyRequest.php
@@ -13,7 +13,7 @@ class DestroyRequest extends FormRequest
      */
     public function authorize()
     {
-        if ($this->user()->isGlobalAdmin()) {
+        if ($this->user()->isContentAdmin()) {
             return true;
         }
 

--- a/app/Http/Requests/Page/ShowRequest.php
+++ b/app/Http/Requests/Page/ShowRequest.php
@@ -13,7 +13,7 @@ class ShowRequest extends FormRequest
      */
     public function authorize()
     {
-        if (!$this->user('api') || !$this->user('api')->isGlobalAdmin()) {
+        if (!$this->user('api') || !$this->user('api')->isContentAdmin()) {
             return $this->page->enabled;
         }
 

--- a/app/Http/Requests/Page/StoreRequest.php
+++ b/app/Http/Requests/Page/StoreRequest.php
@@ -22,7 +22,7 @@ class StoreRequest extends FormRequest
      */
     public function authorize()
     {
-        if ($this->user()->isGlobalAdmin()) {
+        if ($this->user()->isContentAdmin()) {
             return true;
         }
 

--- a/app/Http/Requests/Page/UpdateRequest.php
+++ b/app/Http/Requests/Page/UpdateRequest.php
@@ -25,7 +25,7 @@ class UpdateRequest extends FormRequest
      */
     public function authorize()
     {
-        if ($this->user()->isGlobalAdmin()) {
+        if ($this->user()->isContentAdmin()) {
             return true;
         }
 
@@ -57,7 +57,7 @@ class UpdateRequest extends FormRequest
                     $this->user('api'),
                     new UserRole([
                         'user_id' => $this->user('api')->id,
-                        'role_id' => Role::globalAdmin()->id,
+                        'role_id' => Role::contentAdmin()->id,
                     ]),
                     $this->page->slug
                 ),
@@ -82,7 +82,7 @@ class UpdateRequest extends FormRequest
                     $this->user('api'),
                     new UserRole([
                         'user_id' => $this->user('api')->id,
-                        'role_id' => Role::globalAdmin()->id,
+                        'role_id' => Role::contentAdmin()->id,
                     ]),
                     $this->page->enabled
                 ),

--- a/app/Http/Requests/User/UpdateRequest.php
+++ b/app/Http/Requests/User/UpdateRequest.php
@@ -118,14 +118,17 @@ class UpdateRequest extends FormRequest
                     return 1;
                 case Role::NAME_GLOBAL_ADMIN:
                     return 2;
-                case Role::NAME_ORGANISATION_ADMIN:
+                case Role::NAME_CONTENT_ADMIN:
                     return 3;
-                case Role::NAME_SERVICE_ADMIN:
+                case Role::NAME_ORGANISATION_ADMIN:
                     return 4;
-                case Role::NAME_SERVICE_WORKER:
+                case Role::NAME_SERVICE_ADMIN:
                     return 5;
-                default:
+                case Role::NAME_SERVICE_WORKER:
                     return 6;
+
+                default:
+                    return 7;
             }
         });
     }

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -18,6 +18,8 @@ class Role extends Model
 
     const NAME_ORGANISATION_ADMIN = 'Organisation Admin';
 
+    const NAME_CONTENT_ADMIN = 'Content Admin';
+
     const NAME_GLOBAL_ADMIN = 'Global Admin';
 
     const NAME_SUPER_ADMIN = 'Super Admin';
@@ -49,6 +51,16 @@ class Role extends Model
     {
         return cache()->rememberForever('Role::organisationAdmin', function () {
             return static::query()->where('name', static::NAME_ORGANISATION_ADMIN)->firstOrFail();
+        });
+    }
+
+    /**
+     * @return \App\Models\Role
+     */
+    public static function contentAdmin(): self
+    {
+        return cache()->rememberForever('Role::contentAdmin', function () {
+            return static::query()->where('name', static::NAME_CONTENT_ADMIN)->firstOrFail();
         });
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -254,6 +254,14 @@ class User extends Authenticatable implements Notifiable
         }
 
         /*
+         * If the invoker is a global admin,
+         * and the subject is a content admin.
+         */
+        if ($this->isGlobalAdmin() && $subject->isContentAdmin()) {
+            return true;
+        }
+
+        /*
          * If the invoker is an organisation admin for the organisation,
          * and the subject is not a global admin.
          */
@@ -305,6 +313,14 @@ class User extends Authenticatable implements Notifiable
         }
 
         /*
+         * If the invoker is a global admin,
+         * and the subject is a content admin.
+         */
+        if ($this->isGlobalAdmin() && $subject->isContentAdmin()) {
+            return true;
+        }
+
+        /*
          * If the invoker is an organisation admin for the organisation,
          * and the subject is not a global admin.
          */
@@ -348,7 +364,7 @@ class User extends Authenticatable implements Notifiable
     public function isServiceAdmin(Service $service = null): bool
     {
         return $this->hasRole(Role::serviceAdmin(), $service)
-            || $this->isOrganisationAdmin($service->organisation ?? null);
+        || $this->isOrganisationAdmin($service->organisation ?? null);
     }
 
     /**
@@ -358,6 +374,14 @@ class User extends Authenticatable implements Notifiable
     public function isOrganisationAdmin(Organisation $organisation = null): bool
     {
         return $this->hasRole(Role::organisationAdmin(), null, $organisation) || $this->isGlobalAdmin();
+    }
+
+    /**
+     * @return bool
+     */
+    public function isContentAdmin(): bool
+    {
+        return $this->hasRole(Role::contentAdmin()) || $this->isSuperAdmin();
     }
 
     /**
@@ -411,6 +435,16 @@ class User extends Authenticatable implements Notifiable
         }
 
         $this->assignRole(Role::organisationAdmin(), null, $organisation);
+
+        return $this;
+    }
+
+    /**
+     * @return \App\Models\User
+     */
+    public function makeContentAdmin(): self
+    {
+        $this->assignRole(Role::contentAdmin());
 
         return $this;
     }
@@ -490,6 +524,21 @@ class User extends Authenticatable implements Notifiable
      * @throws \App\Exceptions\CannotRevokeRoleException
      * @return \App\Models\User
      */
+    public function revokeContentAdmin()
+    {
+        if ($this->hasRole(Role::superAdmin())) {
+            throw new CannotRevokeRoleException('Cannot revoke content admin role when user is an super admin');
+        }
+
+        $this->removeRoll(Role::contentAdmin());
+
+        return $this;
+    }
+
+    /**
+     * @throws \App\Exceptions\CannotRevokeRoleException
+     * @return \App\Models\User
+     */
     public function revokeGlobalAdmin()
     {
         if ($this->hasRole(Role::superAdmin())) {
@@ -541,6 +590,14 @@ class User extends Authenticatable implements Notifiable
     /**
      * @return bool
      */
+    public function canMakeContentAdmin(): bool
+    {
+        return $this->isGlobalAdmin();
+    }
+
+    /**
+     * @return bool
+     */
     public function canMakeGlobalAdmin(): bool
     {
         return $this->isGlobalAdmin();
@@ -582,6 +639,15 @@ class User extends Authenticatable implements Notifiable
     public function canRevokeOrganisationAdmin(User $subject, Organisation $organisation): bool
     {
         return $this->canRevokeRole($subject, $organisation);
+    }
+
+    /**
+     * @param \App\Models\User $subject
+     * @return bool
+     */
+    public function canRevokeContentAdmin(User $subject): bool
+    {
+        return $this->canRevokeRole($subject);
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -313,18 +313,10 @@ class User extends Authenticatable implements Notifiable
         }
 
         /*
-         * If the invoker is a global admin,
-         * and the subject is a content admin.
-         */
-        if ($this->isGlobalAdmin() && $subject->isContentAdmin()) {
-            return true;
-        }
-
-        /*
          * If the invoker is an organisation admin for the organisation,
-         * and the subject is not a global admin.
+         * and the subject is not a content admin or a global admin.
          */
-        if ($this->isOrganisationAdmin() && !$subject->isGlobalAdmin()) {
+        if ($this->isOrganisationAdmin() && !($subject->isGlobalAdmin() || $subject->isContentAdmin())) {
             return true;
         }
 
@@ -332,7 +324,7 @@ class User extends Authenticatable implements Notifiable
          * If the invoker is a service admin for the service,
          * and the subject is not a organisation admin for the organisation.
          */
-        if ($this->isServiceAdmin() && !$subject->isOrganisationAdmin()) {
+        if ($this->isServiceAdmin() && !($subject->isOrganisationAdmin() || $subject->isContentAdmin())) {
             return true;
         }
 

--- a/app/Models/UserRole.php
+++ b/app/Models/UserRole.php
@@ -21,8 +21,8 @@ class UserRole extends Model
         $isServiceAdmin = $this->role->name === Role::NAME_SERVICE_WORKER;
 
         return $service
-            ? ($isServiceAdmin && $this->service_id === $service->id)
-            : $isServiceAdmin;
+        ? ($isServiceAdmin && $this->service_id === $service->id)
+        : $isServiceAdmin;
     }
 
     /**
@@ -34,8 +34,8 @@ class UserRole extends Model
         $isServiceAdmin = $this->role->name === Role::NAME_SERVICE_ADMIN;
 
         return $service
-            ? ($isServiceAdmin && $this->service_id === $service->id)
-            : $isServiceAdmin;
+        ? ($isServiceAdmin && $this->service_id === $service->id)
+        : $isServiceAdmin;
     }
 
     /**
@@ -47,8 +47,16 @@ class UserRole extends Model
         $isOrganisationAdmin = $this->role->name === Role::NAME_ORGANISATION_ADMIN;
 
         return $organisation
-            ? ($isOrganisationAdmin && $this->organisation_id === $organisation->id)
-            : $isOrganisationAdmin;
+        ? ($isOrganisationAdmin && $this->organisation_id === $organisation->id)
+        : $isOrganisationAdmin;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isContentAdmin(): bool
+    {
+        return $this->role->name === Role::NAME_CONTENT_ADMIN;
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -19,7 +19,7 @@ class AppServiceProvider extends ServiceProvider
     public function boot()
     {
         // Use CarbonImmutable instead of Carbon.
-        Date::use (CarbonImmutable::class);
+        Date::use(CarbonImmutable::class);
 
         // Geocode.
         switch (config('geocode.geocode_driver')) {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -19,7 +19,7 @@ class AppServiceProvider extends ServiceProvider
     public function boot()
     {
         // Use CarbonImmutable instead of Carbon.
-        Date::use(CarbonImmutable::class);
+        Date::use (CarbonImmutable::class);
 
         // Geocode.
         switch (config('geocode.geocode_driver')) {
@@ -97,6 +97,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        //
+        if ($this->app->environment('local')) {
+            $this->app->register(\Laravel\Telescope\TelescopeServiceProvider::class);
+            $this->app->register(TelescopeServiceProvider::class);
+        }
     }
 }

--- a/app/Providers/TelescopeServiceProvider.php
+++ b/app/Providers/TelescopeServiceProvider.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\Facades\Gate;
+use Laravel\Telescope\IncomingEntry;
+use Laravel\Telescope\Telescope;
+use Laravel\Telescope\TelescopeApplicationServiceProvider;
+
+class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
+{
+    /**
+     * Register any application services.
+     */
+    public function register(): void
+    {
+        // Telescope::night();
+
+        $this->hideSensitiveRequestDetails();
+
+        Telescope::filter(function (IncomingEntry $entry) {
+            if ($this->app->environment('local')) {
+                return true;
+            }
+
+            return $entry->isReportableException() ||
+                   $entry->isFailedRequest() ||
+                   $entry->isFailedJob() ||
+                   $entry->isScheduledTask() ||
+                   $entry->hasMonitoredTag();
+        });
+    }
+
+    /**
+     * Prevent sensitive request details from being logged by Telescope.
+     */
+    protected function hideSensitiveRequestDetails(): void
+    {
+        if ($this->app->environment('local')) {
+            return;
+        }
+
+        Telescope::hideRequestParameters(['_token']);
+
+        Telescope::hideRequestHeaders([
+            'cookie',
+            'x-csrf-token',
+            'x-xsrf-token',
+        ]);
+    }
+
+    /**
+     * Register the Telescope gate.
+     *
+     * This gate determines who can access Telescope in non-local environments.
+     */
+    protected function gate(): void
+    {
+        Gate::define('viewTelescope', function ($user) {
+            return in_array($user->email, [
+                //
+            ]);
+        });
+    }
+}

--- a/app/Rules/CanAssignRoleToUser.php
+++ b/app/Rules/CanAssignRoleToUser.php
@@ -70,6 +70,11 @@ class CanAssignRoleToUser implements Rule
                     return false;
                 }
                 break;
+            case Role::NAME_CONTENT_ADMIN:
+                if (!$this->user->canMakeContentAdmin()) {
+                    return false;
+                }
+                break;
             case Role::NAME_GLOBAL_ADMIN:
                 if (!$this->user->canMakeGlobalAdmin()) {
                     return false;

--- a/app/Rules/UserHasRole.php
+++ b/app/Rules/UserHasRole.php
@@ -58,6 +58,8 @@ class UserHasRole implements Rule
                 return $this->user->isServiceWorker($this->userRole->service);
             case Role::NAME_ORGANISATION_ADMIN:
                 return $this->user->isOrganisationAdmin($this->userRole->organisation);
+            case Role::NAME_CONTENT_ADMIN:
+                return $this->user->isContentAdmin();
             case Role::NAME_GLOBAL_ADMIN:
                 return $this->user->isGlobalAdmin();
             case Role::NAME_SUPER_ADMIN:

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
     "brianium/paratest": "^6.8",
     "fakerphp/faker": "^1.16",
     "friendsofphp/php-cs-fixer": "^3.2",
+    "laravel/telescope": "^4.16",
     "mockery/mockery": "^1.4.4",
     "nunomaduro/collision": "^6.3",
     "pda/pheanstalk": "~4.0",
@@ -68,7 +69,9 @@
   },
   "extra": {
     "laravel": {
-      "dont-discover": []
+      "dont-discover": [
+        "laravel/telescope"
+      ]
     }
   },
   "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b8ff70cde9faec86c3dcb757db641dbb",
+    "content-hash": "3916dd9a254d0c64c28ef7a47f762405",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -10840,6 +10840,77 @@
                 "source": "https://github.com/Jean85/pretty-package-versions/tree/2.0.5"
             },
             "time": "2021-10-08T21:21:46+00:00"
+        },
+        {
+            "name": "laravel/telescope",
+            "version": "v4.16.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/telescope.git",
+                "reference": "05eedc3bf54fd205946bf84d15768e8d3a98d285"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/telescope/zipball/05eedc3bf54fd205946bf84d15768e8d3a98d285",
+                "reference": "05eedc3bf54fd205946bf84d15768e8d3a98d285",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "laravel/framework": "^8.37|^9.0|^10.0",
+                "php": "^8.0",
+                "symfony/var-dumper": "^5.0|^6.0"
+            },
+            "require-dev": {
+                "ext-gd": "*",
+                "guzzlehttp/guzzle": "^6.0|^7.0",
+                "laravel/octane": "^1.4",
+                "orchestra/testbench": "^6.0|^7.0|^8.0",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Telescope\\TelescopeServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Telescope\\": "src/",
+                    "Laravel\\Telescope\\Database\\Factories\\": "database/factories/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                },
+                {
+                    "name": "Mohamed Said",
+                    "email": "mohamed@laravel.com"
+                }
+            ],
+            "description": "An elegant debug assistant for the Laravel framework.",
+            "keywords": [
+                "debugging",
+                "laravel",
+                "monitoring"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/telescope/issues",
+                "source": "https://github.com/laravel/telescope/tree/v4.16.1"
+            },
+            "time": "2023-08-11T14:24:18+00:00"
         },
         {
             "name": "mockery/mockery",

--- a/config/app.php
+++ b/config/app.php
@@ -13,7 +13,7 @@ return [
     | framework needs to place the application's name in a notification or
     | any other location as required by the application or its packages.
     |
-    */
+     */
 
     'name' => env('APP_NAME', 'Laravel'),
 
@@ -26,7 +26,7 @@ return [
     | running in. This may determine how you prefer to configure various
     | services your application utilizes. Set this in your ".env" file.
     |
-    */
+     */
 
     'env' => env('APP_ENV', 'production'),
 
@@ -39,7 +39,7 @@ return [
     | stack traces will be shown on every error that occurs within your
     | application. If disabled, a simple generic error page is shown.
     |
-    */
+     */
 
     'debug' => env('APP_DEBUG', false),
 
@@ -52,7 +52,7 @@ return [
     | the Artisan command line tool. You should set this to the root of
     | your application so that it is used when running Artisan tasks.
     |
-    */
+     */
 
     'url' => env('APP_URL', 'http://localhost'),
 
@@ -65,7 +65,7 @@ return [
     | will be used by the PHP date and date-time functions. We have gone
     | ahead and set this to a sensible default for you out of the box.
     |
-    */
+     */
 
     'timezone' => 'UTC',
 
@@ -78,7 +78,7 @@ return [
     | by the translation service provider. You are free to set this value
     | to any of the locales which will be supported by the application.
     |
-    */
+     */
 
     'locale' => 'en',
 
@@ -91,7 +91,7 @@ return [
     | is not available. You may change the value to correspond to any of
     | the language folders that are provided through your application.
     |
-    */
+     */
 
     'fallback_locale' => 'en',
 
@@ -104,7 +104,7 @@ return [
     | by the faker library. You are free to set this value to any of
     | the locales which will be supported by faker.
     |
-    */
+     */
 
     'faker_locale' => 'en_GB',
 
@@ -117,7 +117,7 @@ return [
     | to a random, 32 character string, otherwise these encrypted strings
     | will not be safe. Please do this before deploying an application!
     |
-    */
+     */
 
     'key' => env('APP_KEY'),
 
@@ -134,7 +134,7 @@ return [
     |
     | Supported drivers: "file", "cache"
     |
-    */
+     */
 
     'maintenance' => [
         'driver' => 'file',
@@ -150,7 +150,7 @@ return [
     | request to your application. Feel free to add your own services to
     | this array to grant expanded functionality to your applications.
     |
-    */
+     */
 
     'providers' => [
 
@@ -213,7 +213,7 @@ return [
     | is started. However, feel free to register as many as you wish as
     | the aliases are "lazy" loaded so they don't hinder performance.
     |
-    */
+     */
 
     'aliases' => Facade::defaultAliases()->merge([
         'Redis' => Illuminate\Support\Facades\Redis::class,

--- a/config/telescope.php
+++ b/config/telescope.php
@@ -1,0 +1,187 @@
+<?php
+
+use Laravel\Telescope\Http\Middleware\Authorize;
+use Laravel\Telescope\Watchers;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Telescope Domain
+    |--------------------------------------------------------------------------
+    |
+    | This is the subdomain where Telescope will be accessible from. If the
+    | setting is null, Telescope will reside under the same domain as the
+    | application. Otherwise, this value will be used as the subdomain.
+    |
+    */
+
+    'domain' => env('TELESCOPE_DOMAIN'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Telescope Path
+    |--------------------------------------------------------------------------
+    |
+    | This is the URI path where Telescope will be accessible from. Feel free
+    | to change this path to anything you like. Note that the URI will not
+    | affect the paths of its internal API that aren't exposed to users.
+    |
+    */
+
+    'path' => env('TELESCOPE_PATH', 'telescope'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Telescope Storage Driver
+    |--------------------------------------------------------------------------
+    |
+    | This configuration options determines the storage driver that will
+    | be used to store Telescope's data. In addition, you may set any
+    | custom options as needed by the particular driver you choose.
+    |
+    */
+
+    'driver' => env('TELESCOPE_DRIVER', 'database'),
+
+    'storage' => [
+        'database' => [
+            'connection' => env('DB_CONNECTION', 'mysql'),
+            'chunk' => 1000,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Telescope Master Switch
+    |--------------------------------------------------------------------------
+    |
+    | This option may be used to disable all Telescope watchers regardless
+    | of their individual configuration, which simply provides a single
+    | and convenient way to enable or disable Telescope data storage.
+    |
+    */
+
+    'enabled' => env('TELESCOPE_ENABLED', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Telescope Route Middleware
+    |--------------------------------------------------------------------------
+    |
+    | These middleware will be assigned to every Telescope route, giving you
+    | the chance to add your own middleware to this list or change any of
+    | the existing middleware. Or, you can simply stick with this list.
+    |
+    */
+
+    'middleware' => [
+        'web',
+        Authorize::class,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Allowed / Ignored Paths & Commands
+    |--------------------------------------------------------------------------
+    |
+    | The following array lists the URI paths and Artisan commands that will
+    | not be watched by Telescope. In addition to this list, some Laravel
+    | commands, like migrations and queue commands, are always ignored.
+    |
+    */
+
+    'only_paths' => [
+        // 'api/*'
+    ],
+
+    'ignore_paths' => [
+        'nova-api*',
+    ],
+
+    'ignore_commands' => [
+        //
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Telescope Watchers
+    |--------------------------------------------------------------------------
+    |
+    | The following array lists the "watchers" that will be registered with
+    | Telescope. The watchers gather the application's profile data when
+    | a request or task is executed. Feel free to customize this list.
+    |
+    */
+
+    'watchers' => [
+        Watchers\BatchWatcher::class => env('TELESCOPE_BATCH_WATCHER', true),
+
+        Watchers\CacheWatcher::class => [
+            'enabled' => env('TELESCOPE_CACHE_WATCHER', true),
+            'hidden' => [],
+        ],
+
+        Watchers\ClientRequestWatcher::class => env('TELESCOPE_CLIENT_REQUEST_WATCHER', true),
+
+        Watchers\CommandWatcher::class => [
+            'enabled' => env('TELESCOPE_COMMAND_WATCHER', true),
+            'ignore' => [],
+        ],
+
+        Watchers\DumpWatcher::class => [
+            'enabled' => env('TELESCOPE_DUMP_WATCHER', true),
+            'always' => env('TELESCOPE_DUMP_WATCHER_ALWAYS', false),
+        ],
+
+        Watchers\EventWatcher::class => [
+            'enabled' => env('TELESCOPE_EVENT_WATCHER', true),
+            'ignore' => [],
+        ],
+
+        Watchers\ExceptionWatcher::class => env('TELESCOPE_EXCEPTION_WATCHER', true),
+
+        Watchers\GateWatcher::class => [
+            'enabled' => env('TELESCOPE_GATE_WATCHER', true),
+            'ignore_abilities' => [],
+            'ignore_packages' => true,
+            'ignore_paths' => [],
+        ],
+
+        Watchers\JobWatcher::class => env('TELESCOPE_JOB_WATCHER', true),
+
+        Watchers\LogWatcher::class => [
+            'enabled' => env('TELESCOPE_LOG_WATCHER', true),
+            'level' => 'error',
+        ],
+
+        Watchers\MailWatcher::class => env('TELESCOPE_MAIL_WATCHER', true),
+
+        Watchers\ModelWatcher::class => [
+            'enabled' => env('TELESCOPE_MODEL_WATCHER', true),
+            'events' => ['eloquent.*'],
+            'hydrations' => true,
+        ],
+
+        Watchers\NotificationWatcher::class => env('TELESCOPE_NOTIFICATION_WATCHER', true),
+
+        Watchers\QueryWatcher::class => [
+            'enabled' => env('TELESCOPE_QUERY_WATCHER', true),
+            'ignore_packages' => true,
+            'ignore_paths' => [],
+            'slow' => 100,
+        ],
+
+        Watchers\RedisWatcher::class => env('TELESCOPE_REDIS_WATCHER', true),
+
+        Watchers\RequestWatcher::class => [
+            'enabled' => env('TELESCOPE_REQUEST_WATCHER', true),
+            'size_limit' => env('TELESCOPE_RESPONSE_SIZE_LIMIT', 64),
+            'ignore_http_methods' => [],
+            'ignore_status_codes' => [],
+        ],
+
+        Watchers\ScheduleWatcher::class => env('TELESCOPE_SCHEDULE_WATCHER', true),
+        Watchers\ViewWatcher::class => env('TELESCOPE_VIEW_WATCHER', true),
+    ],
+];

--- a/database/migrations/2023_08_29_105145_seed_content_admin_role_data.php
+++ b/database/migrations/2023_08_29_105145_seed_content_admin_role_data.php
@@ -5,12 +5,9 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 
-return new class extends Migration
-{
+return new class() extends Migration {
     /**
      * Run the migrations.
-     *
-     * @return void
      */
     public function up()
     {
@@ -26,8 +23,6 @@ return new class extends Migration
 
     /**
      * Reverse the migrations.
-     *
-     * @return void
      */
     public function down()
     {

--- a/database/migrations/2023_08_29_105145_seed_content_admin_role_data.php
+++ b/database/migrations/2023_08_29_105145_seed_content_admin_role_data.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Models\Role;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $now = Date::now();
+
+        DB::table('roles')->insert([
+            'id' => uuid(),
+            'name' => Role::NAME_CONTENT_ADMIN,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::table('roles')->where(Role::NAME_CONTENT_ADMIN)->delete();
+    }
+};

--- a/tests/Feature/UsersTest.php
+++ b/tests/Feature/UsersTest.php
@@ -443,6 +443,95 @@ class UsersTest extends TestCase
     }
 
     /*
+     * Content Admin Invoked.
+     */
+    public function test_content_admin_cannot_create_service_worker()
+    {
+        $service = Service::factory()->create();
+        $user = User::factory()->create()->makeContentAdmin();
+        Passport::actingAs($user);
+
+        $response = $this->json('POST', '/core/v1/users', $this->getCreateUserPayload([
+            [
+                'role' => Role::NAME_SERVICE_WORKER,
+                'service_id' => $service->id,
+            ],
+        ]));
+
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    public function test_content_admin_cannot_create_service_admin()
+    {
+        $service = Service::factory()->create();
+        $user = User::factory()->create()->makeContentAdmin();
+        Passport::actingAs($user);
+
+        $response = $this->json('POST', '/core/v1/users', $this->getCreateUserPayload([
+            [
+                'role' => Role::NAME_SERVICE_ADMIN,
+                'service_id' => $service->id,
+            ],
+        ]));
+
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    public function test_content_admin_cannot_create_organisation_admin()
+    {
+        $service = Service::factory()->create();
+        $user = User::factory()->create()->makeContentAdmin();
+        Passport::actingAs($user);
+
+        $response = $this->json('POST', '/core/v1/users', $this->getCreateUserPayload([
+            [
+                'role' => Role::NAME_ORGANISATION_ADMIN,
+                'organisation_id' => $service->organisation->id,
+            ],
+        ]));
+
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    public function test_content_admin_cannot_create_content_admin()
+    {
+        $service = Service::factory()->create();
+        $user = User::factory()->create()->makeContentAdmin();
+        Passport::actingAs($user);
+
+        $response = $this->json('POST', '/core/v1/users', $this->getCreateUserPayload([
+            ['role' => Role::NAME_CONTENT_ADMIN],
+        ]));
+
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    public function test_content_admin_cannot_create_global_admin()
+    {
+        $service = Service::factory()->create();
+        $user = User::factory()->create()->makeContentAdmin();
+        Passport::actingAs($user);
+
+        $response = $this->json('POST', '/core/v1/users', $this->getCreateUserPayload([
+            ['role' => Role::NAME_GLOBAL_ADMIN],
+        ]));
+
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    public function test_content_admin_cannot_create_super_admin()
+    {
+        $user = User::factory()->create()->makeContentAdmin();
+        Passport::actingAs($user);
+
+        $response = $this->json('POST', '/core/v1/users', $this->getCreateUserPayload([
+            ['role' => Role::NAME_SUPER_ADMIN],
+        ]));
+
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    /*
      * Global Admin Invoked.
      */
     public function test_global_admin_can_create_service_worker()
@@ -1235,6 +1324,188 @@ class UsersTest extends TestCase
     }
 
     /*
+     * Content Admin Invoked.
+     */
+
+    public function test_content_admin_cannot_update_service_worker()
+    {
+        $invoker = User::factory()->create()->makeContentAdmin();
+        Passport::actingAs($invoker);
+
+        $service = Service::factory()->create();
+        $user = User::factory()->create()->makeServiceWorker($service);
+
+        $response = $this->json('PUT', "/core/v1/users/{$user->id}", [
+            'first_name' => $user->first_name,
+            'last_name' => $user->last_name,
+            'email' => $user->email,
+            'phone' => $user->phone,
+            'password' => 'Pa$$w0rd',
+            'roles' => [
+                [
+                    'role' => Role::NAME_SERVICE_WORKER,
+                    'service_id' => $service->id,
+                ],
+            ],
+        ]);
+
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+
+    public function test_content_admin_cannot_update_service_admin()
+    {
+        $invoker = User::factory()->create()->makeContentAdmin();
+        Passport::actingAs($invoker);
+
+        $service = Service::factory()->create();
+        $user = User::factory()->create()->makeServiceAdmin($service);
+
+        $response = $this->json('PUT', "/core/v1/users/{$user->id}", [
+            'first_name' => $user->first_name,
+            'last_name' => $user->last_name,
+            'email' => $user->email,
+            'phone' => $user->phone,
+            'password' => 'Pa$$w0rd',
+            'roles' => [
+                [
+                    'role' => Role::NAME_SERVICE_WORKER,
+                    'service_id' => $service->id,
+                ],
+                [
+                    'role' => Role::NAME_SERVICE_ADMIN,
+                    'service_id' => $service->id,
+                ],
+            ],
+        ]);
+
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+
+    public function test_content_admin_cannot_update_organisation_admin()
+    {
+        $invoker = User::factory()->create()->makeContentAdmin();
+        Passport::actingAs($invoker);
+
+        $service = Service::factory()->create();
+        $user = User::factory()->create()->makeOrganisationAdmin($service->organisation);
+
+        $response = $this->json('PUT', "/core/v1/users/{$user->id}", [
+            'first_name' => $user->first_name,
+            'last_name' => $user->last_name,
+            'email' => $user->email,
+            'phone' => $user->phone,
+            'password' => 'Pa$$w0rd',
+            'roles' => [
+                [
+                    'role' => Role::NAME_SERVICE_WORKER,
+                    'service_id' => $service->id,
+                ],
+                [
+                    'role' => Role::NAME_SERVICE_ADMIN,
+                    'service_id' => $service->id,
+                ],
+                [
+                    'role' => Role::NAME_ORGANISATION_ADMIN,
+                    'organisation_id' => $service->organisation->id,
+                ],
+            ],
+        ]);
+
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+
+    public function test_content_admin_cannot_update_content_admin()
+    {
+        $invoker = User::factory()->create()->makeContentAdmin();
+        Passport::actingAs($invoker);
+
+        $service = Service::factory()->create();
+        $user = User::factory()->create()->makeContentAdmin();
+
+        $response = $this->json('PUT', "/core/v1/users/{$user->id}", [
+            'first_name' => $user->first_name,
+            'last_name' => $user->last_name,
+            'email' => $user->email,
+            'phone' => $user->phone,
+            'password' => 'Pa$$w0rd',
+            'roles' => [
+                ['role' => Role::NAME_CONTENT_ADMIN],
+            ],
+        ]);
+
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+
+    public function test_content_admin_cannot_update_global_admin()
+    {
+        $invoker = User::factory()->create()->makeContentAdmin();
+        Passport::actingAs($invoker);
+
+        $service = Service::factory()->create();
+        $user = User::factory()->create()->makeGlobalAdmin();
+
+        $response = $this->json('PUT', "/core/v1/users/{$user->id}", [
+            'first_name' => $user->first_name,
+            'last_name' => $user->last_name,
+            'email' => $user->email,
+            'phone' => $user->phone,
+            'password' => 'Pa$$w0rd',
+            'roles' => [
+                [
+                    'role' => Role::NAME_SERVICE_WORKER,
+                    'service_id' => $service->id,
+                ],
+                [
+                    'role' => Role::NAME_SERVICE_ADMIN,
+                    'service_id' => $service->id,
+                ],
+                [
+                    'role' => Role::NAME_ORGANISATION_ADMIN,
+                    'organisation_id' => $service->organisation->id,
+                ],
+                ['role' => Role::NAME_GLOBAL_ADMIN],
+            ],
+        ]);
+
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+
+    public function test_content_admin_cannot_update_super_admin()
+    {
+        $invoker = User::factory()->create()->makeContentAdmin();
+        Passport::actingAs($invoker);
+
+        $service = Service::factory()->create();
+        $user = User::factory()->create()->makeSuperAdmin();
+
+        $response = $this->json('PUT', "/core/v1/users/{$user->id}", [
+            'first_name' => $user->first_name,
+            'last_name' => $user->last_name,
+            'email' => $user->email,
+            'phone' => $user->phone,
+            'password' => 'Pa$$w0rd',
+            'roles' => [
+                [
+                    'role' => Role::NAME_SERVICE_WORKER,
+                    'service_id' => $service->id,
+                ],
+                [
+                    'role' => Role::NAME_SERVICE_ADMIN,
+                    'service_id' => $service->id,
+                ],
+                [
+                    'role' => Role::NAME_ORGANISATION_ADMIN,
+                    'organisation_id' => $service->organisation->id,
+                ],
+                ['role' => Role::NAME_GLOBAL_ADMIN],
+                ['role' => Role::NAME_SUPER_ADMIN],
+            ],
+        ]);
+
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+
+    /*
      * Global Admin Invoked.
      */
 
@@ -1392,46 +1663,17 @@ class UsersTest extends TestCase
             'phone' => $user->phone,
             'password' => 'Pa$$w0rd',
             'roles' => [
-                [
-                    'role' => Role::NAME_SERVICE_WORKER,
-                    'service_id' => $service->id,
-                ],
-                [
-                    'role' => Role::NAME_SERVICE_ADMIN,
-                    'service_id' => $service->id,
-                ],
-                [
-                    'role' => Role::NAME_ORGANISATION_ADMIN,
-                    'organisation_id' => $service->organisation->id,
-                ],
                 ['role' => Role::NAME_CONTENT_ADMIN],
             ],
         ]);
 
         $response->assertStatus(Response::HTTP_OK);
+
         $response->assertJsonFragment([
             'first_name' => $user->first_name,
             'last_name' => $user->last_name,
             'email' => $user->email,
             'phone' => $user->phone,
-        ]);
-        $response->assertJsonFragment([
-            [
-                'role' => Role::NAME_SERVICE_WORKER,
-                'service_id' => $service->id,
-            ],
-        ]);
-        $response->assertJsonFragment([
-            [
-                'role' => Role::NAME_SERVICE_ADMIN,
-                'service_id' => $service->id,
-            ],
-        ]);
-        $response->assertJsonFragment([
-            [
-                'role' => Role::NAME_ORGANISATION_ADMIN,
-                'organisation_id' => $service->organisation->id,
-            ],
         ]);
         $response->assertJsonFragment([
             ['role' => Role::NAME_CONTENT_ADMIN],
@@ -1470,6 +1712,7 @@ class UsersTest extends TestCase
         ]);
 
         $response->assertStatus(Response::HTTP_OK);
+
         $response->assertJsonFragment([
             'first_name' => $user->first_name,
             'last_name' => $user->last_name,
@@ -1727,18 +1970,6 @@ class UsersTest extends TestCase
             'phone' => $user->phone,
             'password' => 'Pa$$w0rd',
             'roles' => [
-                [
-                    'role' => Role::NAME_SERVICE_WORKER,
-                    'service_id' => $service->id,
-                ],
-                [
-                    'role' => Role::NAME_SERVICE_ADMIN,
-                    'service_id' => $service->id,
-                ],
-                [
-                    'role' => Role::NAME_ORGANISATION_ADMIN,
-                    'organisation_id' => $service->organisation->id,
-                ],
                 ['role' => Role::NAME_CONTENT_ADMIN],
             ],
         ]);
@@ -1750,24 +1981,7 @@ class UsersTest extends TestCase
             'email' => $user->email,
             'phone' => $user->phone,
         ]);
-        $response->assertJsonFragment([
-            [
-                'role' => Role::NAME_SERVICE_WORKER,
-                'service_id' => $service->id,
-            ],
-        ]);
-        $response->assertJsonFragment([
-            [
-                'role' => Role::NAME_SERVICE_ADMIN,
-                'service_id' => $service->id,
-            ],
-        ]);
-        $response->assertJsonFragment([
-            [
-                'role' => Role::NAME_ORGANISATION_ADMIN,
-                'organisation_id' => $service->organisation->id,
-            ],
-        ]);
+
         $response->assertJsonFragment([
             ['role' => Role::NAME_CONTENT_ADMIN],
         ]);
@@ -2020,6 +2234,18 @@ class UsersTest extends TestCase
         $this->assertSoftDeleted((new User())->getTable(), ['id' => $subject->id]);
     }
 
+    public function test_content_admin_cannot_delete_service_admin()
+    {
+        $service = Service::factory()->create();
+        $invoker = User::factory()->create()->makeContentAdmin();
+        $subject = User::factory()->create()->makeServiceAdmin($service);
+        Passport::actingAs($invoker);
+
+        $response = $this->json('DELETE', "/core/v1/users/{$subject->id}");
+
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+
     public function test_guest_cannot_delete_organisation_admin()
     {
         $service = Service::factory()->create();
@@ -2067,6 +2293,86 @@ class UsersTest extends TestCase
         $this->assertSoftDeleted((new User())->getTable(), ['id' => $subject->id]);
     }
 
+    public function test_content_admin_cannot_delete_organisation_admin()
+    {
+        $service = Service::factory()->create();
+        $invoker = User::factory()->create()->makeContentAdmin();
+        $subject = User::factory()->create()->makeOrganisationAdmin($service->organisation);
+        Passport::actingAs($invoker);
+
+        $response = $this->json('DELETE', "/core/v1/users/{$subject->id}");
+
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+
+    public function test_guest_cannot_delete_content_admin()
+    {
+        $subject = User::factory()->create()->makeContentAdmin();
+
+        $response = $this->json('DELETE', "/core/v1/users/{$subject->id}");
+
+        $response->assertStatus(Response::HTTP_UNAUTHORIZED);
+    }
+
+    public function test_service_worker_cannot_delete_content_admin()
+    {
+        $service = Service::factory()->create();
+        $invoker = User::factory()->create()->makeServiceWorker($service);
+        $subject = User::factory()->create()->makeContentAdmin();
+        Passport::actingAs($invoker);
+
+        $response = $this->json('DELETE', "/core/v1/users/{$subject->id}");
+
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+
+    public function test_service_admin_cannot_delete_content_admin()
+    {
+        $service = Service::factory()->create();
+        $invoker = User::factory()->create()->makeServiceAdmin($service);
+        $subject = User::factory()->create()->makeContentAdmin();
+        Passport::actingAs($invoker);
+
+        $response = $this->json('DELETE', "/core/v1/users/{$subject->id}");
+
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+
+    public function test_organisation_admin_cannot_delete_content_admin()
+    {
+        $service = Service::factory()->create();
+        $invoker = User::factory()->create()->makeOrganisationAdmin($service->organisation);
+        $subject = User::factory()->create()->makeContentAdmin();
+        Passport::actingAs($invoker);
+
+        $response = $this->json('DELETE', "/core/v1/users/{$subject->id}");
+
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+
+    public function test_content_admin_cannot_delete_content_admin()
+    {
+        $invoker = User::factory()->create()->makeContentAdmin();
+        $subject = User::factory()->create()->makeContentAdmin();
+        Passport::actingAs($invoker);
+
+        $response = $this->json('DELETE', "/core/v1/users/{$subject->id}");
+
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+
+    public function test_global_admin_can_delete_content_admin()
+    {
+        $invoker = User::factory()->create()->makeGlobalAdmin();
+        $subject = User::factory()->create()->makeContentAdmin();
+        Passport::actingAs($invoker);
+
+        $response = $this->json('DELETE', "/core/v1/users/{$subject->id}");
+
+        $response->assertStatus(Response::HTTP_OK);
+        $this->assertSoftDeleted((new User())->getTable(), ['id' => $subject->id]);
+    }
+
     public function test_guest_cannot_delete_global_admin()
     {
         $subject = User::factory()->create()->makeGlobalAdmin();
@@ -2100,10 +2406,21 @@ class UsersTest extends TestCase
         $response->assertStatus(Response::HTTP_FORBIDDEN);
     }
 
-    public function test_organisation_admin_can_delete_global_admin()
+    public function test_organisation_admin_cannot_delete_global_admin()
     {
         $service = Service::factory()->create();
         $invoker = User::factory()->create()->makeOrganisationAdmin($service->organisation);
+        $subject = User::factory()->create()->makeGlobalAdmin();
+        Passport::actingAs($invoker);
+
+        $response = $this->json('DELETE', "/core/v1/users/{$subject->id}");
+
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+
+    public function test_content_admin_cannot_delete_global_admin()
+    {
+        $invoker = User::factory()->create()->makeContentAdmin();
         $subject = User::factory()->create()->makeGlobalAdmin();
         Passport::actingAs($invoker);
 
@@ -2157,10 +2474,21 @@ class UsersTest extends TestCase
         $response->assertStatus(Response::HTTP_FORBIDDEN);
     }
 
-    public function test_organisation_admin_can_delete_super_admin()
+    public function test_organisation_admin_cannot_delete_super_admin()
     {
         $service = Service::factory()->create();
         $invoker = User::factory()->create()->makeOrganisationAdmin($service->organisation);
+        $subject = User::factory()->create()->makeSuperAdmin();
+        Passport::actingAs($invoker);
+
+        $response = $this->json('DELETE', "/core/v1/users/{$subject->id}");
+
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+
+    public function test_content_admin_cannot_delete_super_admin()
+    {
+        $invoker = User::factory()->create()->makeContentAdmin();
         $subject = User::factory()->create()->makeSuperAdmin();
         Passport::actingAs($invoker);
 


### PR DESCRIPTION
### Summary

https://app.shortcut.com/helpyourselfsutton/story/2754/create-a-new-content-admin-user-role

- Created new role 'Content Admin'
- Only Global Admin can create Content Admin
- Only Content admin and Super Admin can create, update and delete pages
- All users and guest can view pages

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
