### PR TITLE
Updated permissions delete event only super admin

### DIFF
--- a/app/Docs/Operations/OrganisationEvents/DestroyOrganisationEventOperation.php
+++ b/app/Docs/Operations/OrganisationEvents/DestroyOrganisationEventOperation.php
@@ -20,7 +20,7 @@ class DestroyOrganisationEventOperation extends Operation
             ->action(static::ACTION_DELETE)
             ->tags(OrganisationEventsTag::create())
             ->summary('Delete a specific organisation event')
-            ->description('**Permission:** `Organisation Admin`')
+            ->description('**Permission:** `Super Admin`')
             ->responses(ResourceDeletedResponse::create(null, 'organisation event'));
     }
 }

--- a/app/Http/Requests/OrganisationEvent/DestroyRequest.php
+++ b/app/Http/Requests/OrganisationEvent/DestroyRequest.php
@@ -13,7 +13,7 @@ class DestroyRequest extends FormRequest
      */
     public function authorize()
     {
-        if ($this->user()->isOrganisationAdmin($this->organisation_event->organisation)) {
+        if ($this->user()->isSuperAdmin()) {
             return true;
         }
 

--- a/tests/Feature/OrganisationEventsTest.php
+++ b/tests/Feature/OrganisationEventsTest.php
@@ -511,7 +511,7 @@ class OrganisationEventsTest extends TestCase
     /**
      * @test
      */
-    public function postCreateOrganisationEventAsOrganisationAdmin201()
+    public function postCreateOrganisationEventAsOrganisationAdmin200()
     {
         $organisation = Organisation::factory()->create();
         $location = Location::factory()->create();
@@ -2762,7 +2762,7 @@ class OrganisationEventsTest extends TestCase
     /**
      * @test
      */
-    public function deleteRemoveOrganisationEventAsOrganisationAdmin200()
+    public function deleteRemoveOrganisationEventAsOrganisationAdmin403()
     {
         $organisation = Organisation::factory()->create();
         $user = User::factory()->create()->makeOrganisationAdmin($organisation);
@@ -2775,14 +2775,14 @@ class OrganisationEventsTest extends TestCase
 
         $response = $this->json('DELETE', "/core/v1/organisation-events/{$organisationEvent->id}");
 
-        $response->assertStatus(Response::HTTP_OK);
-        $this->assertDatabaseMissing((new OrganisationEvent())->getTable(), ['id' => $organisationEvent->id]);
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+        $this->assertDatabaseHas((new OrganisationEvent())->getTable(), ['id' => $organisationEvent->id]);
     }
 
     /**
      * @test
      */
-    public function deleteRemoveOrganisationEventAsGlobalAdmin200()
+    public function deleteRemoveOrganisationEventAsGlobalAdmin403()
     {
         $organisation = Organisation::factory()->create();
         $user = User::factory()->create()->makeGlobalAdmin($organisation);
@@ -2793,8 +2793,8 @@ class OrganisationEventsTest extends TestCase
 
         $response = $this->json('DELETE', "/core/v1/organisation-events/{$organisationEvent->id}");
 
-        $response->assertStatus(Response::HTTP_OK);
-        $this->assertDatabaseMissing((new OrganisationEvent())->getTable(), ['id' => $organisationEvent->id]);
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+        $this->assertDatabaseHas((new OrganisationEvent())->getTable(), ['id' => $organisationEvent->id]);
     }
 
     /**
@@ -2818,12 +2818,12 @@ class OrganisationEventsTest extends TestCase
     /**
      * @test
      */
-    public function deleteRemoveOrganisationEventAsOrganisationAdminCreatesAudit200()
+    public function deleteRemoveOrganisationEventAsSuperAdminCreatesAudit200()
     {
         $this->fakeEvents();
 
         $organisation = Organisation::factory()->create();
-        $user = User::factory()->create()->makeOrganisationAdmin($organisation);
+        $user = User::factory()->create()->makeSuperAdmin();
 
         Passport::actingAs($user);
 


### PR DESCRIPTION
### Summary

https://app.shortcut.com/helpyourselfsutton/story/2773/update-user-permissions-api

- Updated delete event permissions. Remove organisation admin and global admin. Only super admin.

### Development checklist

- [x] Changes have been made to the API?
  - [x] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
