### PR TITLE
Allow service admin and up to view update request

### DIFF
--- a/app/Docs/Operations/UpdateRequests/ShowUpdateRequestOperation.php
+++ b/app/Docs/Operations/UpdateRequests/ShowUpdateRequestOperation.php
@@ -23,7 +23,7 @@ class ShowUpdateRequestOperation extends Operation
             ->action(static::ACTION_GET)
             ->tags(UpdateRequestsTag::create())
             ->summary('Get a specific update request')
-            ->description('**Permission:** `Super Admin`')
+            ->description('**Permission:** `Service Admin`')
             ->responses(
                 Response::ok()->content(
                     MediaType::json()->schema(

--- a/app/Http/Requests/UpdateRequest/ShowRequest.php
+++ b/app/Http/Requests/UpdateRequest/ShowRequest.php
@@ -13,7 +13,7 @@ class ShowRequest extends FormRequest
      */
     public function authorize()
     {
-        if ($this->user()->isSuperAdmin()) {
+        if ($this->user()->isServiceAdmin() || $this->user()->isContentAdmin()) {
             return true;
         }
 

--- a/app/Search/ElasticSearch/ServiceQueryBuilder.php
+++ b/app/Search/ElasticSearch/ServiceQueryBuilder.php
@@ -95,12 +95,6 @@ class ServiceQueryBuilder extends ElasticsearchQueryBuilder implements QueryBuil
 
     protected function applyQuery(string $query): void
     {
-        // $this->addMatch('name', $query, $this->shouldPath, 3);
-        // $this->addMatch('organisation_name', $query, $this->shouldPath, 3);
-        // $this->addMatch('intro', $query, $this->shouldPath, 2);
-        // $this->addMatch('description', $query, $this->shouldPath, 1.5);
-        // $this->addMatch('taxonomy_categories', $query, $this->shouldPath);
-
         $this->addMatch('name', $query, $this->shouldPath, 2);
         $this->addMatch('name', $query, $this->shouldPath, 2.5, 'AUTO', 'AND');
         $this->addMatchPhrase('name', $query, $this->shouldPath, 3);

--- a/tests/Feature/UpdateRequestsTest.php
+++ b/tests/Feature/UpdateRequestsTest.php
@@ -177,8 +177,8 @@ class UpdateRequestsTest extends TestCase
             ],
         ]);
 
-        $globalAdminUser = User::factory()->create()->makeSuperAdmin();
-        Passport::actingAs($globalAdminUser);
+        $superAdminUser = User::factory()->create()->makeSuperAdmin();
+        Passport::actingAs($superAdminUser);
 
         $response = $this->json('GET', "/core/v1/update-requests?filter[location_id]={$location->id}");
 
@@ -240,8 +240,8 @@ class UpdateRequestsTest extends TestCase
             ],
         ]);
 
-        $globalAdminUser = User::factory()->create()->makeSuperAdmin();
-        Passport::actingAs($globalAdminUser);
+        $superAdminUser = User::factory()->create()->makeSuperAdmin();
+        Passport::actingAs($superAdminUser);
         $response = $this->json('GET', "/core/v1/update-requests?filter[entry]={$organisation->name}");
 
         $response->assertStatus(Response::HTTP_OK);
@@ -338,7 +338,7 @@ class UpdateRequestsTest extends TestCase
     /**
      * @test
      */
-    public function service_admin_cannot_view_one()
+    public function service_admin_can_view_one()
     {
         $service = Service::factory()->create();
         $user = User::factory()->create()->makeServiceAdmin($service);
@@ -352,13 +352,21 @@ class UpdateRequestsTest extends TestCase
 
         $response = $this->json('GET', "/core/v1/update-requests/{$updateRequest->id}");
 
-        $response->assertStatus(Response::HTTP_FORBIDDEN);
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertJsonFragment([
+            'id' => $updateRequest->id,
+            'user_id' => $updateRequest->user_id,
+            'actioning_user_id' => null,
+            'updateable_type' => UpdateRequest::EXISTING_TYPE_SERVICE_LOCATION,
+            'updateable_id' => $serviceLocation->id,
+            'data' => ['name' => 'Test Name'],
+        ]);
     }
 
     /**
      * @test
      */
-    public function organisation_admin_cannot_view_one()
+    public function organisation_admin_can_view_one()
     {
         $organisation = Organisation::factory()->create();
         $user = User::factory()->create()->makeOrganisationAdmin($organisation);
@@ -372,13 +380,21 @@ class UpdateRequestsTest extends TestCase
 
         $response = $this->json('GET', "/core/v1/update-requests/{$updateRequest->id}");
 
-        $response->assertStatus(Response::HTTP_FORBIDDEN);
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertJsonFragment([
+            'id' => $updateRequest->id,
+            'user_id' => $updateRequest->user_id,
+            'actioning_user_id' => null,
+            'updateable_type' => UpdateRequest::EXISTING_TYPE_SERVICE_LOCATION,
+            'updateable_id' => $serviceLocation->id,
+            'data' => ['name' => 'Test Name'],
+        ]);
     }
 
     /**
      * @test
      */
-    public function global_admin_cannot_view_one()
+    public function global_admin_can_view_one()
     {
         $user = User::factory()->create()->makeGlobalAdmin();
         Passport::actingAs($user);
@@ -391,7 +407,15 @@ class UpdateRequestsTest extends TestCase
 
         $response = $this->json('GET', "/core/v1/update-requests/{$updateRequest->id}");
 
-        $response->assertStatus(Response::HTTP_FORBIDDEN);
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertJsonFragment([
+            'id' => $updateRequest->id,
+            'user_id' => $updateRequest->user_id,
+            'actioning_user_id' => null,
+            'updateable_type' => UpdateRequest::EXISTING_TYPE_SERVICE_LOCATION,
+            'updateable_id' => $serviceLocation->id,
+            'data' => ['name' => 'Test Name'],
+        ]);
     }
 
     /**


### PR DESCRIPTION
### Summary

https://app.shortcut.com/helpyourselfsutton/story/2773/update-user-permissions-api

- Allow all users who can create update requests to view update request singular

### Development checklist

- [x] Changes have been made to the API?
  - [x] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
