### PR TITLE
Moved rate limit to config and increased default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,6 +119,9 @@ CQC_LOCATION=false
 # Enable the Service Tags functionality
 SERVICE_TAGS=false
 
+# The request rate limit per minute for the api
+API_RATE_LIMIT=300
+
 # Passport keys.
 # Once ./develop artisan passport:keys has been run
 # Copy and paste the contents of storage/oauth-private.key

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -118,7 +118,7 @@ class RouteServiceProvider extends ServiceProvider
     protected function configureRateLimiting()
     {
         RateLimiter::for('api', function (Request $request) {
-            return Limit::perMinute(60)->by($request->user()?->id ?: $request->ip());
+            return Limit::perMinute(config('local.api_rate_limit'))->by($request->user()?->id ?: $request->ip());
         });
     }
 }

--- a/config/local.php
+++ b/config/local.php
@@ -46,4 +46,8 @@ return [
         150,
         350,
     ],
+    /**
+     * The request api rate limit per minute per user / IP.
+     */
+    'api_rate_limit' => env('API_RATE_LIMIT', 300),
 ];

--- a/tests/Feature/PagesTest.php
+++ b/tests/Feature/PagesTest.php
@@ -3498,6 +3498,44 @@ class PagesTest extends TestCase
     /**
      * @test
      */
+    public function updatePageEnablePageAsContentAdmin200()
+    {
+        /**
+         * @var \App\Models\User $user
+         */
+        $user = User::factory()->create()->makeContentAdmin();
+
+        Passport::actingAs($user);
+
+        $page = Page::factory()->disabled()->create();
+
+        $data = [
+            'enabled' => true,
+        ];
+
+        $response = $this->json('PUT', '/core/v1/pages/' . $page->id, $data);
+
+        $response->assertStatus(Response::HTTP_OK);
+
+        $updateRequest = UpdateRequest::find($response->json()['id']);
+
+        $this->assertEquals($data, $updateRequest->data);
+
+        $this->assertFalse($page->fresh()->enabled);
+
+        $this->approveUpdateRequest($updateRequest->id);
+
+        $this->assertTrue($page->fresh()->enabled);
+
+        $this->assertDatabaseHas(table(Page::class), [
+            'id' => $page->id,
+            'enabled' => true,
+        ]);
+    }
+
+    /**
+     * @test
+     */
     public function updatePageDisabledCascadestoChildPagesAsContentAdmin200()
     {
         /**


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/3377/api-rate-limits

- Moved api request rate limit into config key "local.api_rate_limit" that is based on environment variable "API_RATE_LIMIT"
- Set default rate limit to 300 request per minute per user / IP

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
