### PR TITLE
Resolved issues with mailgun and twilio integrations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,6 +84,7 @@ MAIL_FROM_NAME=
 # The Mailgun credentails.
 MAILGUN_DOMAIN=
 MAILGUN_SECRET=
+# USA: https://api.mailgun.net EU: https://api.eu.mailgun.net
 MAILGUN_ENDPOINT=
 
 # The SMS configuration.

--- a/app/EmailSenders/GovNotifyEmailSender.php
+++ b/app/EmailSenders/GovNotifyEmailSender.php
@@ -41,7 +41,7 @@ class GovNotifyEmailSender implements EmailSender
         $email->notification->update(['message' => $response['content']['body']]);
 
         if (config('app.debug')) {
-            logger()->debug('Email sent', $response);
+            logger()->debug('Email sent via Gov Notify', $response);
         }
     }
 }

--- a/app/EmailSenders/LogEmailSender.php
+++ b/app/EmailSenders/LogEmailSender.php
@@ -27,7 +27,7 @@ class LogEmailSender implements EmailSender
      */
     public function send(Email $email)
     {
-        logger()->debug('Email sent at [' . Date::now()->toDateTimeString() . ']', [
+        logger()->debug('Email sent via Log at [' . Date::now()->toDateTimeString() . ']', [
             'to' => $email->to,
             'templateId' => $email->templateId,
             'values' => array_merge($this->globalValues, $email->values),

--- a/app/EmailSenders/MailgunEmailSender.php
+++ b/app/EmailSenders/MailgunEmailSender.php
@@ -92,7 +92,7 @@ class MailgunEmailSender implements EmailSender
         $email->notification->update(['message' => $content]);
 
         if (config('app.debug')) {
-            logger()->debug('Email sent', (array)$response);
+            logger()->debug('Email sent via Mailgun', (array)$response);
         }
     }
 }

--- a/app/Http/Requests/Referral/StoreRequest.php
+++ b/app/Http/Requests/Referral/StoreRequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests\Referral;
 
 use App\Models\Taxonomy;
 use App\Rules\RootTaxonomyIs;
+use App\Rules\UkMobilePhoneNumber;
 use App\Rules\UkPhoneNumber;
 use Illuminate\Foundation\Http\FormRequest;
 
@@ -31,7 +32,7 @@ class StoreRequest extends FormRequest
             'service_id' => ['required', 'exists:services,id'],
             'name' => ['required', 'string', 'min:1', 'max:255'],
             'email' => ['required_without_all:phone,other_contact', 'nullable', 'email', 'max:255'],
-            'phone' => ['required_without_all:email,other_contact', 'nullable', 'string', 'min:1', 'max:255', new UkPhoneNumber()],
+            'phone' => ['required_without_all:email,other_contact', 'nullable', 'string', 'min:1', 'max:255', new UkMobilePhoneNumber()],
             'other_contact' => ['required_without_all:phone,email', 'nullable', 'string', 'min:1', 'max:255'],
             'postcode_outward_code' => ['present', 'nullable', 'string', 'min:1', 'max:255'],
             'comments' => ['present', 'nullable', 'string', 'min:1', 'max:255'],
@@ -62,5 +63,15 @@ class StoreRequest extends FormRequest
         }
 
         return $rules;
+    }
+
+    /**
+     * Prepare the data for validation.
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'phone' => str_replace(' ', '', $this->phone),
+        ]);
     }
 }

--- a/app/Models/Notification.php
+++ b/app/Models/Notification.php
@@ -51,6 +51,7 @@ class Notification extends Model
 
             // Add the email as a job on the queue to be sent.
             $email->notification = $notification;
+
             app(Dispatcher::class)->dispatch($email);
         });
     }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -36,7 +36,7 @@ class AppServiceProvider extends ServiceProvider
         }
 
         // Email Sender.
-        switch (config('mail.driver')) {
+        switch (config('mail.default')) {
             case 'gov':
                 $this->app->singleton(\App\Contracts\EmailSender::class, \App\EmailSenders\GovNotifyEmailSender::class);
                 break;

--- a/app/Providers/TwilioServiceProvider.php
+++ b/app/Providers/TwilioServiceProvider.php
@@ -14,8 +14,8 @@ class TwilioServiceProvider extends ServiceProvider
     {
         $this->app->singleton(Client::class, function () {
             return new Client(
-                config('tlr.twilio.sid'),
-                config('tlr.twilio.token')
+                config('sms.twilio.sid'),
+                config('sms.twilio.token')
             );
         });
     }

--- a/app/Rules/UkMobilePhoneNumber.php
+++ b/app/Rules/UkMobilePhoneNumber.php
@@ -41,7 +41,7 @@ class UkMobilePhoneNumber implements Rule
             return true;
         }
 
-        $matches = preg_match('/^(\+44[0-9]{10})$/', $value);
+        $matches = preg_match('/^(\+447[0-9]{9})$/', $value);
 
         if ($matches === 1) {
             return true;

--- a/app/Rules/UkMobilePhoneNumber.php
+++ b/app/Rules/UkMobilePhoneNumber.php
@@ -37,7 +37,17 @@ class UkMobilePhoneNumber implements Rule
 
         $matches = preg_match('/^(07[0-9]{9})$/', $value);
 
-        return $matches === 1;
+        if ($matches === 1) {
+            return true;
+        }
+
+        $matches = preg_match('/^(\+44[0-9]{10})$/', $value);
+
+        if ($matches === 1) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/app/SmsSenders/GovNotifySmsSender.php
+++ b/app/SmsSenders/GovNotifySmsSender.php
@@ -41,7 +41,7 @@ class GovNotifySmsSender implements SmsSender
         $sms->notification->update(['message' => $response['content']['body']]);
 
         if (config('app.debug')) {
-            logger()->debug('SMS sent', $response);
+            logger()->debug('SMS sent via Gov notify', $response);
         }
     }
 }

--- a/app/SmsSenders/LogSmsSender.php
+++ b/app/SmsSenders/LogSmsSender.php
@@ -13,7 +13,7 @@ class LogSmsSender implements SmsSender
      */
     public function send(Sms $sms)
     {
-        logger()->debug('SMS sent at [' . Date::now()->toDateTimeString() . ']', [
+        logger()->debug('SMS sent via Log SMS at [' . Date::now()->toDateTimeString() . ']', [
             'to' => $sms->to,
             'templateId' => $sms->templateId,
             'values' => $sms->values,

--- a/app/SmsSenders/TwilioSmsSender.php
+++ b/app/SmsSenders/TwilioSmsSender.php
@@ -55,7 +55,7 @@ class TwilioSmsSender implements SmsSender
      */
     public function ukToInternationalNumber(string $ukMobileNumber)
     {
-        $matches = preg_match('/^(\+44[0-9]{10})$/', $ukMobileNumber);
+        $matches = preg_match('/^(\+447[0-9]{9})$/', $ukMobileNumber);
         if ($matches === 1) {
             return $ukMobileNumber;
         }

--- a/lang/en/sms.php
+++ b/lang/en/sms.php
@@ -1,6 +1,6 @@
 <?php
 
 return [
-    'otp' => require './sms/otp.php',
-    'referral' => require './sms/referral.php',
+    'otp' => require 'sms/otp.php',
+    'referral' => require 'sms/referral.php',
 ];


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/3376/twilio-and-mailgun-integrations-are-not-working

- Updated AppServiceProvider to use new config key for mail sender
- Updated Mailgun integration
- Updated Twilio integration
- Updated UkMobilePhoneNumber Rule to accept either '07' numbers or '+447' numbers

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
