### PR TITLE
Bug/sc 3555/organisation report accounts attributed calculation

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -730,7 +730,16 @@ class User extends Authenticatable implements Notifiable
      */
     public function visibleUserIds()
     {
-        if ($this->isGlobalAdmin() && !$this->isSuperAdmin()) {
+        // Super admin can see all users
+        if ($this->isSuperAdmin()) {
+            return User::query()
+                ->pluck('id')
+                ->concat([$this->id])
+                ->unique();
+        }
+
+        // Global Admin can only see self
+        if ($this->isGlobalAdmin()) {
             return collect([$this->id]);
         }
         // Get the service IDs from all the organisations the user belongs to
@@ -759,15 +768,6 @@ class User extends Authenticatable implements Notifiable
             ])
         );
 
-        // Super admin can see global and content admins
-        if ($this->isSuperAdmin()) {
-            $userIds = $userIds->concat(
-                User::globalAdmins()->pluck('id')
-            );
-            $userIds = $userIds->concat(
-                User::contentAdmins()->pluck('id')
-            );
-        }
         // Include this user
         return $userIds
             ->concat([$this->id])

--- a/tests/Unit/Models/ReportTest.php
+++ b/tests/Unit/Models/ReportTest.php
@@ -282,6 +282,7 @@ class ReportTest extends TestCase
 
         // Create an admin and non-admin user.
         User::factory()->create()->makeSuperAdmin();
+        User::factory()->create()->makeGlobalAdmin();
         User::factory()->create()->makeOrganisationAdmin($organisation);
 
         $headings = [
@@ -321,6 +322,13 @@ class ReportTest extends TestCase
         $service = Service::factory()->create([
             'organisation_id' => $organisation->id,
         ]);
+
+        User::factory()->create()->makeServiceAdmin($service);
+        User::factory()->create()->makeServiceWorker($service);
+        // Soft deleted organisation admin
+        $deletedUser = User::factory()->create()->makeOrganisationAdmin($organisation);
+        $deletedUser->delete();
+        $this->assertTrue($deletedUser->trashed());
 
         // Generate the report.
         $report = Report::generate(ReportType::organisationsExport());


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/3555/organisation-report-accounts-attributed-calculation-wrong

- Sub query to count the associated accounts was including super and global admins

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [ ] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
