### PR TITLE
Added explicit binding for StatefulGuard for AuthorizationController

### DIFF
--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,8 +2,11 @@
 
 namespace App\Providers;
 
+use App\Http\Controllers\Passport\AuthorizationController;
 use App\Models\Client;
+use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Date;
 use Laravel\Passport\Passport;
 
@@ -26,6 +29,10 @@ class AuthServiceProvider extends ServiceProvider
         Passport::enableImplicitGrant();
         Passport::tokensExpireIn(Date::now()->addMonths(18));
         Passport::useClientModel(Client::class);
+
+        $this->app->when(AuthorizationController::class)
+            ->needs(StatefulGuard::class)
+            ->give(fn () => Auth::guard(config('passport.guard', null)));
     }
 
     /**

--- a/routes/passport.php
+++ b/routes/passport.php
@@ -2,6 +2,9 @@
 
 use Illuminate\Support\Facades\Route;
 
-Route::get('oauth/authorize', [\App\Http\Controllers\Passport\AuthorizationController::class, 'authorize']);
-Route::post('oauth/authorize', [\Laravel\Passport\Http\Controllers\ApproveAuthorizationController::class, 'approve']);
-Route::delete('oauth/authorize', [\Laravel\Passport\Http\Controllers\DenyAuthorizationController::class, 'deny']);
+Route::get('oauth/authorize', [\App\Http\Controllers\Passport\AuthorizationController::class, 'authorize'])
+    ->name('authorizations.authorize');
+Route::post('oauth/authorize', [\Laravel\Passport\Http\Controllers\ApproveAuthorizationController::class, 'approve'])
+    ->name('authorizations.approve');
+Route::delete('oauth/authorize', [\Laravel\Passport\Http\Controllers\DenyAuthorizationController::class, 'deny'])
+    ->name('authorizations.delete');

--- a/tests/Feature/PagesTest.php
+++ b/tests/Feature/PagesTest.php
@@ -172,7 +172,7 @@ class PagesTest extends TestCase
             $disabledLandingPage->id,
         ];
 
-        $response = $this->json('GET', '/core/v1/pages/index?filter[id]='.implode(',', $ids));
+        $response = $this->json('GET', '/core/v1/pages/index?filter[id]=' . implode(',', $ids));
 
         $response->assertStatus(Response::HTTP_OK);
         $response->assertJsonCount(2, 'data');
@@ -221,7 +221,7 @@ class PagesTest extends TestCase
             $disabledLandingPage->id,
         ];
 
-        $response = $this->json('GET', '/core/v1/pages/index?filter[id]='.implode(',', $ids));
+        $response = $this->json('GET', '/core/v1/pages/index?filter[id]=' . implode(',', $ids));
 
         $response->assertStatus(Response::HTTP_OK);
         $response->assertJsonCount(4, 'data');
@@ -253,7 +253,7 @@ class PagesTest extends TestCase
         $page1 = Page::factory()->withChildren()->create();
         $page2 = Page::factory()->withChildren()->create();
 
-        $response = $this->json('GET', '/core/v1/pages/index?filter[parent_id]='.$page1->id);
+        $response = $this->json('GET', '/core/v1/pages/index?filter[parent_id]=' . $page1->id);
 
         $response->assertStatus(Response::HTTP_OK);
         $response->assertJsonCount(3, 'data');
@@ -290,7 +290,7 @@ class PagesTest extends TestCase
     {
         $landingPage = Page::factory()->landingPage()->withChildren()->create();
 
-        $response = $this->json('GET', '/core/v1/pages/index?filter[parent_id]='.$landingPage->id);
+        $response = $this->json('GET', '/core/v1/pages/index?filter[parent_id]=' . $landingPage->id);
 
         $response->assertStatus(Response::HTTP_OK);
         $response->assertJsonCount(3, 'data');
@@ -640,7 +640,7 @@ class PagesTest extends TestCase
         $landingPage1->appendNode($parent);
         $landingPage2 = Page::factory()->landingPage()->withChildren()->create();
 
-        $response = $this->json('GET', '/core/v1/pages/index?filter[landing_page]='.$landingPage1->id.'&include=parent');
+        $response = $this->json('GET', '/core/v1/pages/index?filter[landing_page]=' . $landingPage1->id . '&include=parent');
         $response->assertStatus(Response::HTTP_OK);
         $response->assertJsonStructure([
             'data' => [
@@ -1286,7 +1286,7 @@ class PagesTest extends TestCase
 
         // Assigned Images not allowed
         $image = File::factory()->create([
-            'filename' => Str::random().'.png',
+            'filename' => Str::random() . '.png',
             'mime_type' => 'image/png',
         ]);
 
@@ -1723,12 +1723,12 @@ class PagesTest extends TestCase
         $parentPage = Page::factory()->create();
 
         $image = File::factory()->pendingAssignment()->create([
-            'filename' => Str::random().'.png',
+            'filename' => Str::random() . '.png',
             'mime_type' => 'image/png',
         ]);
 
         $image->uploadBase64EncodedFile(
-            'data:image/png;base64,'.base64_encode(Storage::disk('local')->get('/test-data/image.png'))
+            'data:image/png;base64,' . base64_encode(Storage::disk('local')->get('/test-data/image.png'))
         );
 
         $data = [
@@ -1794,12 +1794,12 @@ class PagesTest extends TestCase
         $parentPage = Page::factory()->create();
 
         $image = File::factory()->pendingAssignment()->create([
-            'filename' => Str::random().'.jpg',
+            'filename' => Str::random() . '.jpg',
             'mime_type' => 'image/jpeg',
         ]);
 
         $image->uploadBase64EncodedFile(
-            'data:image/jpeg;base64,'.base64_encode(Storage::disk('local')->get('/test-data/image.jpg'))
+            'data:image/jpeg;base64,' . base64_encode(Storage::disk('local')->get('/test-data/image.jpg'))
         );
 
         $data = [
@@ -1865,12 +1865,12 @@ class PagesTest extends TestCase
         $parentPage = Page::factory()->create();
 
         $image = File::factory()->pendingAssignment()->create([
-            'filename' => Str::random().'.svg',
+            'filename' => Str::random() . '.svg',
             'mime_type' => 'image/svg+xml',
         ]);
 
         $image->uploadBase64EncodedFile(
-            'data:image/svg+xml;base64,'.base64_encode(Storage::disk('local')->get('/test-data/image.svg'))
+            'data:image/svg+xml;base64,' . base64_encode(Storage::disk('local')->get('/test-data/image.svg'))
         );
 
         $data = [
@@ -2455,7 +2455,7 @@ class PagesTest extends TestCase
     {
         $page = Page::factory()->withImage()->withParent()->withChildren()->create();
 
-        $response = $this->json('GET', '/core/v1/pages/'.$page->id);
+        $response = $this->json('GET', '/core/v1/pages/' . $page->id);
         $response->assertStatus(Response::HTTP_OK);
         $response->assertJsonResource([
             'id',
@@ -2511,7 +2511,7 @@ class PagesTest extends TestCase
     {
         $page = Page::factory()->withImage()->landingPage()->withChildren()->create();
 
-        $response = $this->json('GET', '/core/v1/pages/'.$page->id);
+        $response = $this->json('GET', '/core/v1/pages/' . $page->id);
         $response->assertStatus(Response::HTTP_OK);
         $response->assertJsonResource([
             'id',
@@ -2556,7 +2556,7 @@ class PagesTest extends TestCase
     {
         $page = Page::factory()->withImage()->withParent()->withChildren()->create();
 
-        $response = $this->json('GET', '/core/v1/pages/'.$page->slug);
+        $response = $this->json('GET', '/core/v1/pages/' . $page->slug);
         $response->assertStatus(Response::HTTP_OK);
         $response->assertJsonFragment([
             'id' => $page->id,
@@ -2574,7 +2574,7 @@ class PagesTest extends TestCase
         $landingPage = Page::factory()->landingPage()->create();
         $landingPage->appendNode($parent);
 
-        $response = $this->json('GET', '/core/v1/pages/'.$page->id);
+        $response = $this->json('GET', '/core/v1/pages/' . $page->id);
         $response->assertStatus(Response::HTTP_OK);
         $response->assertJsonResource([
             'id',
@@ -2647,7 +2647,7 @@ class PagesTest extends TestCase
 
         $page = Page::factory()->create();
 
-        $this->json('GET', '/core/v1/pages/'.$page->id);
+        $this->json('GET', '/core/v1/pages/' . $page->id);
 
         Event::assertDispatched(EndpointHit::class, function (EndpointHit $event) {
             return $event->getAction() === Audit::ACTION_READ;
@@ -2662,7 +2662,7 @@ class PagesTest extends TestCase
         $page = Page::factory()->withImage()->withParent()->withChildren()->disabled()
             ->create();
 
-        $response = $this->json('GET', '/core/v1/pages/'.$page->id);
+        $response = $this->json('GET', '/core/v1/pages/' . $page->id);
 
         $response->assertStatus(Response::HTTP_FORBIDDEN);
     }
@@ -2683,7 +2683,7 @@ class PagesTest extends TestCase
         $page = Page::factory()->withImage()->withParent()->withChildren()->disabled()
             ->create();
 
-        $response = $this->json('GET', '/core/v1/pages/'.$page->id);
+        $response = $this->json('GET', '/core/v1/pages/' . $page->id);
 
         $response->assertStatus(Response::HTTP_OK);
         $response->assertJsonResource([
@@ -2741,11 +2741,11 @@ class PagesTest extends TestCase
         $parentPage = Page::factory()->create();
 
         $image = File::factory()->pendingAssignment()->create([
-            'filename' => Str::random().'.png',
+            'filename' => Str::random() . '.png',
             'mime_type' => 'image/png',
         ]);
 
-        $base64Image = 'data:image/png;base64,'.base64_encode(Storage::disk('local')->get('/test-data/image.png'));
+        $base64Image = 'data:image/png;base64,' . base64_encode(Storage::disk('local')->get('/test-data/image.png'));
 
         $image->uploadBase64EncodedFile($base64Image);
 
@@ -2753,9 +2753,9 @@ class PagesTest extends TestCase
             'image_file_id' => $image->id,
         ]);
 
-        $response = $this->json('GET', '/core/v1/pages/'.$page->id.'/image.png');
+        $response = $this->json('GET', '/core/v1/pages/' . $page->id . '/image.png');
         $response->assertStatus(Response::HTTP_OK);
-        $this->assertEquals($base64Image, 'data:image/png;base64,'.base64_encode($response->content()));
+        $this->assertEquals($base64Image, 'data:image/png;base64,' . base64_encode($response->content()));
     }
 
     /**
@@ -2766,11 +2766,11 @@ class PagesTest extends TestCase
         $parentPage = Page::factory()->create();
 
         $image = File::factory()->pendingAssignment()->create([
-            'filename' => Str::random().'.jpg',
+            'filename' => Str::random() . '.jpg',
             'mime_type' => 'image/jepg',
         ]);
 
-        $base64Image = 'data:image/jpeg;base64,'.base64_encode(Storage::disk('local')->get('/test-data/image.jpg'));
+        $base64Image = 'data:image/jpeg;base64,' . base64_encode(Storage::disk('local')->get('/test-data/image.jpg'));
 
         $image->uploadBase64EncodedFile($base64Image);
 
@@ -2778,9 +2778,9 @@ class PagesTest extends TestCase
             'image_file_id' => $image->id,
         ]);
 
-        $response = $this->json('GET', '/core/v1/pages/'.$page->id.'/image.jpg');
+        $response = $this->json('GET', '/core/v1/pages/' . $page->id . '/image.jpg');
         $response->assertStatus(Response::HTTP_OK);
-        $this->assertEquals($base64Image, 'data:image/jpeg;base64,'.base64_encode($response->content()));
+        $this->assertEquals($base64Image, 'data:image/jpeg;base64,' . base64_encode($response->content()));
     }
 
     /**
@@ -2791,11 +2791,11 @@ class PagesTest extends TestCase
         $parentPage = Page::factory()->create();
 
         $image = File::factory()->pendingAssignment()->create([
-            'filename' => Str::random().'.svg',
+            'filename' => Str::random() . '.svg',
             'mime_type' => 'image/svg+xml',
         ]);
 
-        $base64Image = 'data:image/svg+xml;base64,'.base64_encode(Storage::disk('local')->get('/test-data/image.svg'));
+        $base64Image = 'data:image/svg+xml;base64,' . base64_encode(Storage::disk('local')->get('/test-data/image.svg'));
 
         $image->uploadBase64EncodedFile($base64Image);
 
@@ -2803,9 +2803,9 @@ class PagesTest extends TestCase
             'image_file_id' => $image->id,
         ]);
 
-        $response = $this->json('GET', '/core/v1/pages/'.$page->id.'/image.svg');
+        $response = $this->json('GET', '/core/v1/pages/' . $page->id . '/image.svg');
         $response->assertStatus(Response::HTTP_OK);
-        $this->assertEquals($base64Image, 'data:image/svg+xml;base64,'.base64_encode($response->content()));
+        $this->assertEquals($base64Image, 'data:image/svg+xml;base64,' . base64_encode($response->content()));
     }
 
     /**
@@ -2824,7 +2824,7 @@ class PagesTest extends TestCase
             'title' => 'New Title',
         ];
 
-        $response = $this->json('PUT', '/core/v1/pages/'.$page->id, $data);
+        $response = $this->json('PUT', '/core/v1/pages/' . $page->id, $data);
 
         $response->assertStatus(Response::HTTP_UNAUTHORIZED);
     }
@@ -2844,7 +2844,7 @@ class PagesTest extends TestCase
             'title' => 'New Title',
         ];
 
-        $response = $this->json('PUT', '/core/v1/pages/'.$page->id, $data);
+        $response = $this->json('PUT', '/core/v1/pages/' . $page->id, $data);
 
         $response->assertStatus(Response::HTTP_FORBIDDEN);
     }
@@ -2864,7 +2864,7 @@ class PagesTest extends TestCase
             'title' => 'New Title',
         ];
 
-        $response = $this->json('PUT', '/core/v1/pages/'.$page->id, $data);
+        $response = $this->json('PUT', '/core/v1/pages/' . $page->id, $data);
 
         $response->assertStatus(Response::HTTP_FORBIDDEN);
     }
@@ -2884,7 +2884,7 @@ class PagesTest extends TestCase
             'title' => 'New Title',
         ];
 
-        $response = $this->json('PUT', '/core/v1/pages/'.$page->id, $data);
+        $response = $this->json('PUT', '/core/v1/pages/' . $page->id, $data);
 
         $response->assertStatus(Response::HTTP_FORBIDDEN);
     }
@@ -2903,7 +2903,7 @@ class PagesTest extends TestCase
             'title' => 'New Title',
         ];
 
-        $response = $this->json('PUT', '/core/v1/pages/'.$page->id, $data);
+        $response = $this->json('PUT', '/core/v1/pages/' . $page->id, $data);
 
         $response->assertStatus(Response::HTTP_FORBIDDEN);
     }
@@ -2920,14 +2920,19 @@ class PagesTest extends TestCase
 
         Passport::actingAs($user);
 
-        $page = Page::factory()->withImage()->withParent()->withChildren()->disabled()
+        $page = Page::factory()
+            ->withImage()
+            ->withParent()
+            ->withChildren()
+            ->disabled()
             ->create();
 
         $data = [
             'title' => 'New Title',
+            'enabled' => true,
         ];
 
-        $response = $this->json('PUT', '/core/v1/pages/'.$page->id, $data);
+        $response = $this->json('PUT', '/core/v1/pages/' . $page->id, $data);
 
         $response->assertStatus(Response::HTTP_OK);
 
@@ -2946,11 +2951,18 @@ class PagesTest extends TestCase
 
         $this->assertEquals($data, $updateRequest->data);
 
+        $this->assertDatabaseHas(table(Page::class), [
+            'id' => $page->id,
+            'title' => $page->title,
+            'enabled' => false,
+        ]);
+
         $this->approveUpdateRequest($updateRequest->id);
 
         $this->assertDatabaseHas(table(Page::class), [
             'id' => $page->id,
             'title' => 'New Title',
+            'enabled' => true,
         ]);
     }
 
@@ -2967,14 +2979,19 @@ class PagesTest extends TestCase
 
         Passport::actingAs($user);
 
-        $page = Page::factory()->withImage()->withParent()->withChildren()->disabled()
+        $page = Page::factory()
+            ->withImage()
+            ->withParent()
+            ->withChildren()
+            ->disabled()
             ->create();
 
         $payload = [
             'title' => 'New Title',
+            'enabled' => true,
         ];
 
-        $response = $this->json('PUT', '/core/v1/pages/'.$page->id, $payload);
+        $response = $this->json('PUT', '/core/v1/pages/' . $page->id, $payload);
 
         $response->assertStatus(Response::HTTP_OK);
 
@@ -3012,7 +3029,7 @@ class PagesTest extends TestCase
             'title' => 'New Title',
         ];
 
-        $this->json('PUT', '/core/v1/pages/'.$page->id, $data);
+        $this->json('PUT', '/core/v1/pages/' . $page->id, $data);
 
         Event::assertDispatched(EndpointHit::class, function (EndpointHit $event) {
             return $event->getAction() === Audit::ACTION_UPDATE;
@@ -3035,36 +3052,36 @@ class PagesTest extends TestCase
         $page = Page::factory()->withImage()->withParent()->withChildren()->disabled()
             ->create();
 
-        $this->json('PUT', '/core/v1/pages/'.$page->id, [
+        $this->json('PUT', '/core/v1/pages/' . $page->id, [
             'title' => '',
         ])->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
-        $this->json('PUT', '/core/v1/pages/'.$page->id, [
+        $this->json('PUT', '/core/v1/pages/' . $page->id, [
             'content' => '',
         ])->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
-        $this->json('PUT', '/core/v1/pages/'.$page->id, [
+        $this->json('PUT', '/core/v1/pages/' . $page->id, [
             'title' => '',
             'content' => '',
         ])->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
-        $this->json('PUT', '/core/v1/pages/'.$page->id, [
+        $this->json('PUT', '/core/v1/pages/' . $page->id, [
             'content' => $this->faker->realText(),
         ])->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
-        $this->json('PUT', '/core/v1/pages/'.$page->id, [
+        $this->json('PUT', '/core/v1/pages/' . $page->id, [
             'parent_id' => $this->faker->uuid(),
         ])->assertStatus(Response::HTTP_NOT_FOUND);
 
-        $this->json('PUT', '/core/v1/pages/'.$page->id, [
+        $this->json('PUT', '/core/v1/pages/' . $page->id, [
             'order' => $page->siblingsAndSelf()->count() + 1,
         ])->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
-        $this->json('PUT', '/core/v1/pages/'.$page->id, [
+        $this->json('PUT', '/core/v1/pages/' . $page->id, [
             'order' => -1,
         ])->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
-        $this->json('PUT', '/core/v1/pages/'.$page->id, [
+        $this->json('PUT', '/core/v1/pages/' . $page->id, [
             'page_type' => Page::PAGE_TYPE_LANDING,
         ])->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
@@ -3072,11 +3089,11 @@ class PagesTest extends TestCase
          * Assigned Images not allowed
          */
         $image = File::factory()->create([
-            'filename' => Str::random().'.png',
+            'filename' => Str::random() . '.png',
             'mime_type' => 'image/png',
         ]);
 
-        $this->json('PUT', '/core/v1/pages/'.$page->id, [
+        $this->json('PUT', '/core/v1/pages/' . $page->id, [
             'image_file_id' => $image->id,
         ])->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
     }
@@ -3095,12 +3112,12 @@ class PagesTest extends TestCase
         Passport::actingAs($user);
 
         $image = File::factory()->pendingAssignment()->create([
-            'filename' => Str::random().'.jpg',
+            'filename' => Str::random() . '.jpg',
             'mime_type' => 'image/jpeg',
         ]);
 
         $image->uploadBase64EncodedFile(
-            'data:image/jpeg;base64,'.base64_encode(Storage::disk('local')->get('/test-data/image.jpg'))
+            'data:image/jpeg;base64,' . base64_encode(Storage::disk('local')->get('/test-data/image.jpg'))
         );
 
         $page = Page::factory()->withParent()->withChildren()->disabled()
@@ -3110,7 +3127,7 @@ class PagesTest extends TestCase
             'image_file_id' => $image->id,
         ];
 
-        $response = $this->json('PUT', '/core/v1/pages/'.$page->id, $data);
+        $response = $this->json('PUT', '/core/v1/pages/' . $page->id, $data);
 
         $response->assertStatus(Response::HTTP_OK);
 
@@ -3151,12 +3168,12 @@ class PagesTest extends TestCase
         Passport::actingAs($user);
 
         $image = File::factory()->create([
-            'filename' => Str::random().'.jpg',
+            'filename' => Str::random() . '.jpg',
             'mime_type' => 'image/jpeg',
         ]);
 
         $image->uploadBase64EncodedFile(
-            'data:image/jpeg;base64,'.base64_encode(Storage::disk('local')->get('/test-data/image.jpg'))
+            'data:image/jpeg;base64,' . base64_encode(Storage::disk('local')->get('/test-data/image.jpg'))
         );
 
         $page = Page::factory()->withParent()->withChildren()->disabled()
@@ -3168,7 +3185,7 @@ class PagesTest extends TestCase
             'image_file_id' => null,
         ];
 
-        $response = $this->json('PUT', '/core/v1/pages/'.$page->id, $data);
+        $response = $this->json('PUT', '/core/v1/pages/' . $page->id, $data);
 
         $response->assertStatus(Response::HTTP_OK);
 
@@ -3209,21 +3226,21 @@ class PagesTest extends TestCase
         Passport::actingAs($user);
 
         $imageJpg = File::factory()->create([
-            'filename' => Str::random().'.jpg',
+            'filename' => Str::random() . '.jpg',
             'mime_type' => 'image/jpeg',
         ]);
 
         $imageJpg->uploadBase64EncodedFile(
-            'data:image/jpeg;base64,'.base64_encode(Storage::disk('local')->get('/test-data/image.jpg'))
+            'data:image/jpeg;base64,' . base64_encode(Storage::disk('local')->get('/test-data/image.jpg'))
         );
 
         $imagePng = File::factory()->pendingAssignment()->create([
-            'filename' => Str::random().'.png',
+            'filename' => Str::random() . '.png',
             'mime_type' => 'image/png',
         ]);
 
         $imagePng->uploadBase64EncodedFile(
-            'data:image/png;base64,'.base64_encode(Storage::disk('local')->get('/test-data/image.png'))
+            'data:image/png;base64,' . base64_encode(Storage::disk('local')->get('/test-data/image.png'))
         );
 
         $page = Page::factory()->withParent()->withChildren()->disabled()
@@ -3235,7 +3252,7 @@ class PagesTest extends TestCase
             'image_file_id' => $imagePng->id,
         ];
 
-        $response = $this->json('PUT', '/core/v1/pages/'.$page->id, $data);
+        $response = $this->json('PUT', '/core/v1/pages/' . $page->id, $data);
 
         $response->assertStatus(Response::HTTP_OK);
 
@@ -3287,7 +3304,7 @@ class PagesTest extends TestCase
             'parent_id' => $parentPage2->id,
         ];
 
-        $response = $this->json('PUT', '/core/v1/pages/'.$page->id, $data);
+        $response = $this->json('PUT', '/core/v1/pages/' . $page->id, $data);
 
         $response->assertStatus(Response::HTTP_OK);
 
@@ -3339,7 +3356,7 @@ class PagesTest extends TestCase
             'parent_id' => $parentPage2->id,
         ];
 
-        $response = $this->json('PUT', '/core/v1/pages/'.$page->id, $data);
+        $response = $this->json('PUT', '/core/v1/pages/' . $page->id, $data);
 
         $response->assertStatus(Response::HTTP_OK);
 
@@ -3390,7 +3407,7 @@ class PagesTest extends TestCase
             'page_type' => Page::PAGE_TYPE_LANDING,
         ];
 
-        $response = $this->json('PUT', '/core/v1/pages/'.$page->id, $data);
+        $response = $this->json('PUT', '/core/v1/pages/' . $page->id, $data);
 
         $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
@@ -3399,7 +3416,7 @@ class PagesTest extends TestCase
             'parent_id' => null,
         ];
 
-        $response = $this->json('PUT', '/core/v1/pages/'.$page->id, $data);
+        $response = $this->json('PUT', '/core/v1/pages/' . $page->id, $data);
 
         $response->assertStatus(Response::HTTP_OK);
 
@@ -3448,7 +3465,7 @@ class PagesTest extends TestCase
             'order' => 2,
         ];
 
-        $response = $this->json('PUT', '/core/v1/pages/'.$children->get(1)->id, $data);
+        $response = $this->json('PUT', '/core/v1/pages/' . $children->get(1)->id, $data);
 
         $response->assertStatus(Response::HTTP_OK);
 
@@ -3462,7 +3479,7 @@ class PagesTest extends TestCase
 
         $this->assertEquals($children->get(1)->id, $children->get(2)->getNextSibling()->id);
 
-        $reponse = $this->getJson('/core/v1/pages/'.$children->get(1)->id);
+        $reponse = $this->getJson('/core/v1/pages/' . $children->get(1)->id);
 
         $reponse->assertJsonFragment([
             'order' => 2,
@@ -3472,7 +3489,7 @@ class PagesTest extends TestCase
             'order' => 0,
         ];
 
-        $response = $this->json('PUT', '/core/v1/pages/'.$children->get(1)->id, $data);
+        $response = $this->json('PUT', '/core/v1/pages/' . $children->get(1)->id, $data);
 
         $response->assertStatus(Response::HTTP_OK);
 
@@ -3486,7 +3503,7 @@ class PagesTest extends TestCase
 
         $this->assertEquals($children->get(0)->id, $children->get(1)->getNextSibling()->id);
 
-        $reponse = $this->getJson('/core/v1/pages/'.$children->get(1)->id);
+        $reponse = $this->getJson('/core/v1/pages/' . $children->get(1)->id);
 
         $reponse->assertJsonFragment([
             'order' => 0,
@@ -3511,7 +3528,7 @@ class PagesTest extends TestCase
             'enabled' => true,
         ];
 
-        $response = $this->json('PUT', '/core/v1/pages/'.$page->id, $data);
+        $response = $this->json('PUT', '/core/v1/pages/' . $page->id, $data);
 
         $response->assertStatus(Response::HTTP_OK);
 
@@ -3553,7 +3570,7 @@ class PagesTest extends TestCase
             'enabled' => 0,
         ];
 
-        $response = $this->json('PUT', '/core/v1/pages/'.$parent->id, $data);
+        $response = $this->json('PUT', '/core/v1/pages/' . $parent->id, $data);
 
         $response->assertStatus(Response::HTTP_OK);
 
@@ -3576,7 +3593,7 @@ class PagesTest extends TestCase
             'enabled' => 1,
         ];
 
-        $response = $this->json('PUT', '/core/v1/pages/'.$parent->id, $data);
+        $response = $this->json('PUT', '/core/v1/pages/' . $parent->id, $data);
 
         $response->assertStatus(Response::HTTP_OK);
 
@@ -3616,7 +3633,7 @@ class PagesTest extends TestCase
         $data = [
             'collections' => $collections->pluck('id'),
         ];
-        $response = $this->json('PUT', '/core/v1/pages/'.$page->id, $data);
+        $response = $this->json('PUT', '/core/v1/pages/' . $page->id, $data);
 
         $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
     }
@@ -3641,7 +3658,7 @@ class PagesTest extends TestCase
         $data = [
             'collections' => $collections->pluck('id')->all(),
         ];
-        $response = $this->json('PUT', '/core/v1/pages/'.$page->id, $data);
+        $response = $this->json('PUT', '/core/v1/pages/' . $page->id, $data);
 
         $response->assertStatus(Response::HTTP_OK);
 
@@ -3702,7 +3719,7 @@ class PagesTest extends TestCase
         $data = [
             'collections' => $collectionIds->all(),
         ];
-        $response = $this->json('PUT', '/core/v1/pages/'.$page->id, $data);
+        $response = $this->json('PUT', '/core/v1/pages/' . $page->id, $data);
 
         $response->assertStatus(Response::HTTP_OK);
 
@@ -3777,7 +3794,7 @@ class PagesTest extends TestCase
             'title' => 'New Title',
         ];
 
-        $response = $this->json('PUT', '/core/v1/pages/'.$page->id, $data);
+        $response = $this->json('PUT', '/core/v1/pages/' . $page->id, $data);
 
         $response->assertStatus(Response::HTTP_OK);
 
@@ -3797,7 +3814,7 @@ class PagesTest extends TestCase
             'slug' => 'new-title',
         ];
 
-        $response = $this->json('PUT', '/core/v1/pages/'.$page->id, $data);
+        $response = $this->json('PUT', '/core/v1/pages/' . $page->id, $data);
 
         $response->assertStatus(Response::HTTP_OK);
 
@@ -3826,7 +3843,7 @@ class PagesTest extends TestCase
             'slug' => 'existing-page',
         ];
 
-        $response = $this->json('PUT', '/core/v1/pages/'.$page->id, $data);
+        $response = $this->json('PUT', '/core/v1/pages/' . $page->id, $data);
 
         $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
     }
@@ -3842,7 +3859,7 @@ class PagesTest extends TestCase
     {
         $page = Page::factory()->create();
 
-        $response = $this->json('DELETE', '/core/v1/pages/'.$page->id);
+        $response = $this->json('DELETE', '/core/v1/pages/' . $page->id);
 
         $response->assertStatus(Response::HTTP_UNAUTHORIZED);
     }
@@ -3859,7 +3876,7 @@ class PagesTest extends TestCase
 
         $page = Page::factory()->create();
 
-        $response = $this->json('DELETE', '/core/v1/pages/'.$page->id);
+        $response = $this->json('DELETE', '/core/v1/pages/' . $page->id);
 
         $response->assertStatus(Response::HTTP_FORBIDDEN);
 
@@ -3878,7 +3895,7 @@ class PagesTest extends TestCase
 
         $page = Page::factory()->create();
 
-        $response = $this->json('DELETE', '/core/v1/pages/'.$page->id);
+        $response = $this->json('DELETE', '/core/v1/pages/' . $page->id);
 
         $response->assertStatus(Response::HTTP_FORBIDDEN);
 
@@ -3897,7 +3914,7 @@ class PagesTest extends TestCase
 
         $page = Page::factory()->create();
 
-        $response = $this->json('DELETE', '/core/v1/pages/'.$page->id);
+        $response = $this->json('DELETE', '/core/v1/pages/' . $page->id);
 
         $response->assertStatus(Response::HTTP_FORBIDDEN);
 
@@ -3915,7 +3932,7 @@ class PagesTest extends TestCase
 
         $page = Page::factory()->create();
 
-        $response = $this->json('DELETE', '/core/v1/pages/'.$page->id);
+        $response = $this->json('DELETE', '/core/v1/pages/' . $page->id);
 
         $response->assertStatus(Response::HTTP_FORBIDDEN);
 
@@ -3936,7 +3953,7 @@ class PagesTest extends TestCase
 
         $page = Page::factory()->create();
 
-        $response = $this->json('DELETE', '/core/v1/pages/'.$page->id);
+        $response = $this->json('DELETE', '/core/v1/pages/' . $page->id);
 
         $response->assertStatus(Response::HTTP_FORBIDDEN);
     }
@@ -3955,7 +3972,7 @@ class PagesTest extends TestCase
 
         $page = Page::factory()->create();
 
-        $response = $this->json('DELETE', '/core/v1/pages/'.$page->id);
+        $response = $this->json('DELETE', '/core/v1/pages/' . $page->id);
 
         $response->assertStatus(Response::HTTP_OK);
 
@@ -3979,7 +3996,7 @@ class PagesTest extends TestCase
 
         $page = Page::factory()->create();
 
-        $this->json('DELETE', '/core/v1/pages/'.$page->id);
+        $this->json('DELETE', '/core/v1/pages/' . $page->id);
 
         Event::assertDispatched(EndpointHit::class, function (EndpointHit $event) {
             return $event->getAction() === Audit::ACTION_DELETE;
@@ -4005,7 +4022,7 @@ class PagesTest extends TestCase
 
         $children = $page->children()->defaultOrder()->get();
 
-        $response = $this->json('DELETE', '/core/v1/pages/'.$page->id);
+        $response = $this->json('DELETE', '/core/v1/pages/' . $page->id);
 
         $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
@@ -4035,7 +4052,7 @@ class PagesTest extends TestCase
 
         $children = $page->children()->defaultOrder()->get();
 
-        $response = $this->json('DELETE', '/core/v1/pages/'.$page->id);
+        $response = $this->json('DELETE', '/core/v1/pages/' . $page->id);
 
         $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
@@ -4062,7 +4079,7 @@ class PagesTest extends TestCase
 
         $pageCollectionIds = $page->collections()->pluck('id');
 
-        $response = $this->json('DELETE', '/core/v1/pages/'.$page->id);
+        $response = $this->json('DELETE', '/core/v1/pages/' . $page->id);
 
         $response->assertStatus(Response::HTTP_OK);
 
@@ -4090,7 +4107,7 @@ class PagesTest extends TestCase
 
         $pageCollectionIds = $page->collections()->pluck('id');
 
-        $response = $this->json('DELETE', '/core/v1/pages/'.$page->id);
+        $response = $this->json('DELETE', '/core/v1/pages/' . $page->id);
 
         $response->assertStatus(Response::HTTP_OK);
 
@@ -4118,7 +4135,7 @@ class PagesTest extends TestCase
 
         $imageId = $page->image_file_id;
 
-        $response = $this->json('DELETE', '/core/v1/pages/'.$page->id);
+        $response = $this->json('DELETE', '/core/v1/pages/' . $page->id);
 
         $response->assertStatus(Response::HTTP_OK);
 


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/3414/status-field-is-not-being-honored-for-new-pages

- Added test to check status update on Page was being honoured by update request
- Added explicit binding for StatefulGuard for AuthorizationController to AuthProvider

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
