### PR TITLE
Added Access-Control-Expose-Headers header to file response

### DIFF
--- a/app/Models/File.php
+++ b/app/Models/File.php
@@ -70,6 +70,7 @@ class File extends Model implements Responsable
     public function toResponse($request): Response
     {
         return response()->make($this->getContent(), Response::HTTP_OK, [
+            'Access-Control-Expose-Headers' => ['Content-Type', 'Content-Disposition'],
             'Content-Type' => $this->mime_type,
             'Content-Disposition' => sprintf('inline; filename="%s"', $this->filename),
         ]);


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/3594/reports-don-t-seem-to-be-downloading-anymore

- Report downloads were failing as the `Content-Disposition` header was being hidden by the default CORS policy
- Added `'Access-Control-Expose-Headers' => ['Content-Type', 'Content-Disposition']` header to file http responses which will prevent the header being hidden

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
