### PR TITLE
Update env.example with instructions for SQS Queue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,11 +52,17 @@ SESSION_LIFETIME=20
 # The queue configuration.
 # sqs if using AWS SQS
 QUEUE_CONNECTION=sync
-NOTIFICATIONS_QUEUE=
 
 # The AWS SQS config.
-# Cloudformation Template Outputs: DefaultQueueUrl (remove the word 'default' from the end but leave the dash)
+# Cloudformation Template Outputs: DefaultQueueUrl up to last forward slash
+# e.g. https://sqs.[]AWS Default region].amazonaws.com/[AWS Account ID]/
 SQS_PREFIX=
+# Cloudformation Template Outputs: DefaultQueueUrl after last forward slash
+# e.g. [environment]-[UUID]-default
+SQS_QUEUE=
+# If using SQS: Cloudformation Template Outputs: DefaultQueueUrl after last forward slash, replace default with notifications queue name
+# e.g. [environment]-[UUID]-notifications
+NOTIFICATIONS_QUEUE=
 
 # The cache configuration
 CACHE_DRIVER=redis

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -48,6 +48,11 @@ COPY usr/local/bin/start-container.sh /usr/local/bin/start-container.sh
 COPY packaged /var/www/html
 RUN chown -R www-data: /var/www/html
 
+# Increase the soft ulimit nofiles for users
+RUN sed -i '/End of file/ i *        soft        nofile        4096\n' /etc/security/limits.conf && \
+sed -i '/end of pam-auth-update/ i session required        pam_limits.so' /etc/pam.d/common-session
+
+
 # Expose port 80 for HTTP access.
 EXPOSE 80
 


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/3370/deploy-updated-api-to-new-env

- Laravel sqsQueue driver altered the way it built AWS SQS Queue URLs and was inserting a trailing slash before the word default, causing requests to AWS SQS Queues to fail.
- The way the SQS_PREFIX and SQS_QUEUE environment variables are stored is now different and is documented in `.env.example`

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
