### PR TITLE
Changed the name of the index page includes to match the docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,9 +32,11 @@ DB_USERNAME=connected_places
 DB_PASSWORD=secret
 
 # The AWS credentials.
-# AWS IAM user api-staging Access Key ID
+# These are created for the IAM user api-[environment], e.g. api-staging
+# Under 'Security Credentials' click 'Create Access key' and choose 'Local code' for the use case
+# AWS IAM user Access Key ID
 AWS_ACCESS_KEY_ID=
-# AWS IAM user api-staging Access Key Secret
+# AWS IAM user Access Key Secret
 AWS_SECRET_ACCESS_KEY=
 # The region the Cloudformation stack was deployed in
 AWS_DEFAULT_REGION=

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /public/storage
 /public/mix-manifest.json
 /storage/*.key
+/resources/assets/img/*
 /vendor
 /.idea
 /.vscode

--- a/app/Http/Controllers/Core/V1/PageController.php
+++ b/app/Http/Controllers/Core/V1/PageController.php
@@ -2,24 +2,24 @@
 
 namespace App\Http\Controllers\Core\V1;
 
-use App\Models\Page;
 use App\Events\EndpointHit;
-use Illuminate\Support\Facades\DB;
 use App\Http\Controllers\Controller;
-use App\Http\Resources\PageResource;
-use Spatie\QueryBuilder\QueryBuilder;
-use Spatie\QueryBuilder\AllowedFilter;
-use App\Http\Requests\Page\ShowRequest;
-use App\Http\Responses\ResourceDeleted;
-use Spatie\QueryBuilder\AllowedInclude;
+use App\Http\Requests\Page\DestroyRequest;
 use App\Http\Requests\Page\IndexRequest;
+use App\Http\Requests\Page\ShowRequest;
 use App\Http\Requests\Page\StoreRequest;
 use App\Http\Requests\Page\UpdateRequest;
-use App\Http\Requests\Page\DestroyRequest;
+use App\Http\Resources\PageResource;
+use App\Http\Responses\ResourceDeleted;
 use App\Http\Responses\UpdateRequestReceived;
+use App\Models\Page;
 use App\Models\UpdateRequest as UpdateRequestModel;
 use App\Services\DataPersistence\PagePersistenceService;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Support\Facades\DB;
+use Spatie\QueryBuilder\AllowedFilter;
+use Spatie\QueryBuilder\AllowedInclude;
+use Spatie\QueryBuilder\QueryBuilder;
 
 class PageController extends Controller
 {

--- a/app/Http/Controllers/Core/V1/PageController.php
+++ b/app/Http/Controllers/Core/V1/PageController.php
@@ -2,24 +2,24 @@
 
 namespace App\Http\Controllers\Core\V1;
 
+use App\Models\Page;
 use App\Events\EndpointHit;
+use Illuminate\Support\Facades\DB;
 use App\Http\Controllers\Controller;
-use App\Http\Requests\Page\DestroyRequest;
-use App\Http\Requests\Page\IndexRequest;
+use App\Http\Resources\PageResource;
+use Spatie\QueryBuilder\QueryBuilder;
+use Spatie\QueryBuilder\AllowedFilter;
 use App\Http\Requests\Page\ShowRequest;
+use App\Http\Responses\ResourceDeleted;
+use Spatie\QueryBuilder\AllowedInclude;
+use App\Http\Requests\Page\IndexRequest;
 use App\Http\Requests\Page\StoreRequest;
 use App\Http\Requests\Page\UpdateRequest;
-use App\Http\Resources\PageResource;
-use App\Http\Responses\ResourceDeleted;
+use App\Http\Requests\Page\DestroyRequest;
 use App\Http\Responses\UpdateRequestReceived;
-use App\Models\Page;
 use App\Models\UpdateRequest as UpdateRequestModel;
 use App\Services\DataPersistence\PagePersistenceService;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
-use Illuminate\Support\Facades\DB;
-use Spatie\QueryBuilder\AllowedFilter;
-use Spatie\QueryBuilder\AllowedInclude;
-use Spatie\QueryBuilder\QueryBuilder;
 
 class PageController extends Controller
 {
@@ -49,7 +49,7 @@ class PageController extends Controller
             ->allowedIncludes([
                 'parent',
                 'children',
-                AllowedInclude::relationship('landing-page-ancestors', 'landingPageAncestors'),
+                AllowedInclude::relationship('landingPageAncestors', 'landingPageAncestors'),
             ])
             ->allowedFilters([
                 AllowedFilter::scope('landing_page', 'pageDescendants'),

--- a/tests/Feature/PagesTest.php
+++ b/tests/Feature/PagesTest.php
@@ -2,21 +2,21 @@
 
 namespace Tests\Feature;
 
-use App\Events\EndpointHit;
-use App\Models\Audit;
-use App\Models\Collection;
+use Tests\TestCase;
 use App\Models\File;
 use App\Models\Page;
-use App\Models\Service;
-use App\Models\UpdateRequest;
 use App\Models\User;
+use App\Models\Audit;
+use App\Models\Service;
+use App\Models\Collection;
+use App\Events\EndpointHit;
 use Faker\Factory as Faker;
+use Illuminate\Support\Str;
+use App\Models\UpdateRequest;
 use Illuminate\Http\Response;
+use Laravel\Passport\Passport;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\Str;
-use Laravel\Passport\Passport;
-use Tests\TestCase;
 
 class PagesTest extends TestCase
 {
@@ -566,7 +566,7 @@ class PagesTest extends TestCase
     {
         Page::factory()->withParent()->withChildren()->create();
 
-        $response = $this->json('GET', '/core/v1/pages/index?include=landing-page-ancestors');
+        $response = $this->json('GET', '/core/v1/pages/index?include=landingPageAncestors');
         $response->assertStatus(Response::HTTP_OK);
         $response->assertJsonStructure([
             'data' => [


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/3626/pages-side-nav-menu-missing

- Pages index include `landingPageAncestors` had at some point been changed to `landing_page_ancestors` but the docs were not updated, so calls with the `landingPageAncestors` include were failing
- It was decided to revert to `landingPageAncestors` as this is consistent with the docs

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
