### PR TITLE
Added reindexing for services and events to collection syncTaxonomies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,10 +112,6 @@ SCOUT_DRIVER=elastic
 # Cloudformation Template Outputs: ElasticsearchHost (should start with https:// and end with :443 removing any trailing slash)
 ELASTIC_HOST=elasticsearch:9200
 ELASTIC_MIGRATIONS_CONNECTION=mysql
-SCOUT_ELASTIC_PORT=9200
-SCOUT_ELASTIC_SCHEME=http
-SCOUT_ELASTIC_USERNAME=null
-SCOUT_ELASTIC_PASSWORD=null
 
 # Should Telescope be enabled
 TELESCOPE_ENABLED=false

--- a/app/Models/CollectionTaxonomy.php
+++ b/app/Models/CollectionTaxonomy.php
@@ -14,7 +14,7 @@ class CollectionTaxonomy extends Model
 
     public function touchServices(): CollectionTaxonomy
     {
-        static::services($this)->get()->each->save();
+        static::services($this)->get()->searchable();
 
         return $this;
     }

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -111,7 +111,7 @@ class Location extends Model implements AppliesUpdateRequests
 
     public function touchServices(): Location
     {
-        $this->services()->get()->each->save();
+        $this->services()->get()->searchable();
 
         return $this;
     }

--- a/app/Models/Organisation.php
+++ b/app/Models/Organisation.php
@@ -116,7 +116,7 @@ class Organisation extends Model implements AppliesUpdateRequests, HasTaxonomyRe
 
     public function touchServices(): Organisation
     {
-        $this->services()->get()->each->save();
+        $this->services()->get()->searchable();
 
         return $this;
     }

--- a/app/Models/Taxonomy.php
+++ b/app/Models/Taxonomy.php
@@ -54,7 +54,7 @@ class Taxonomy extends Model
 
     public function touchServices(): Taxonomy
     {
-        $this->services()->get()->each->save();
+        $this->services()->get()->searchable();
 
         return $this;
     }

--- a/config/scout.php
+++ b/config/scout.php
@@ -13,7 +13,7 @@ return [
     |
     | Supported: "algolia", "meilisearch", "database", "collection", "null"
     |
-    */
+     */
 
     'driver' => env('SCOUT_DRIVER', 'algolia'),
 
@@ -26,7 +26,7 @@ return [
     | names used by Scout. This prefix may be useful if you have multiple
     | "tenants" or applications sharing the same search infrastructure.
     |
-    */
+     */
 
     'prefix' => env('SCOUT_PREFIX', ''),
 
@@ -39,9 +39,12 @@ return [
     | with your search engines are queued. When this is set to "true" then
     | all automatic data syncing will get queued for better performance.
     |
-    */
+     */
 
-    'queue' => env('SCOUT_QUEUE', false),
+    'queue' => [
+        'connection' => env('QUEUE_CONNECTION', 'sync'),
+        'queue' => 'search',
+    ],
 
     /*
     |--------------------------------------------------------------------------
@@ -52,7 +55,7 @@ return [
     | with your search indexes after every open database transaction has
     | been committed, thus preventing any discarded data from syncing.
     |
-    */
+     */
 
     'after_commit' => false,
 
@@ -65,7 +68,7 @@ return [
     | mass importing data into the search engine. This allows you to fine
     | tune each of these chunk sizes based on the power of the servers.
     |
-    */
+     */
 
     'chunk' => [
         'searchable' => 500,
@@ -81,7 +84,7 @@ return [
     | the search indexes. Maintaining soft deleted records can be useful
     | if your application still needs to search for the records later.
     |
-    */
+     */
 
     'soft_delete' => false,
 
@@ -96,7 +99,7 @@ return [
     |
     | Supported engines: "algolia"
     |
-    */
+     */
 
     'identify' => env('SCOUT_IDENTIFY', false),
 
@@ -109,7 +112,7 @@ return [
     | search engine which works great with Scout out of the box. Just plug
     | in your application ID and admin API key to get started searching.
     |
-    */
+     */
 
     'algolia' => [
         'id' => env('ALGOLIA_APP_ID', ''),
@@ -127,7 +130,7 @@ return [
     |
     | See: https://docs.meilisearch.com/guides/advanced_guides/configuration.html
     |
-    */
+     */
 
     'meilisearch' => [
         'host' => env('MEILISEARCH_HOST', 'http://localhost:7700'),

--- a/tests/Unit/Models/CollectionTest.php
+++ b/tests/Unit/Models/CollectionTest.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use Tests\TestCase;
+use App\Models\Service;
+use App\Models\Taxonomy;
+use App\Models\Collection;
+use Tests\UsesElasticsearch;
+use App\Models\OrganisationEvent;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+
+class CollectionTest extends TestCase implements UsesElasticsearch
+{
+    /**
+     * @test
+     */
+    public function updateCollectionTaxonomiesReIndexesRelatedServices()
+    {
+        $service1 = Service::factory()->create([
+            'name' => 'Undeniable Giraffe',
+        ]);
+        $service2 = Service::factory()->create([
+            'name' => 'Accomplished Possum',
+        ]);
+        $collection = Collection::create([
+            'type' => Collection::TYPE_CATEGORY,
+            'slug' => 'adventurous-animals',
+            'name' => 'Adventurous Animals',
+            'meta' => [],
+            'order' => 1,
+        ]);
+        $taxonomy1 = Taxonomy::category()->children()->create([
+            'slug' => 'test-taxonomy-1',
+            'name' => 'Test Taxonomy 1',
+            'order' => 1,
+            'depth' => 1,
+        ]);
+        $taxonomy2 = Taxonomy::category()->children()->create([
+            'slug' => 'test-taxonomy-2',
+            'name' => 'Test Taxonomy 2',
+            'order' => 2,
+            'depth' => 1,
+        ]);
+
+        // Attach services to taxonomies
+        $service1->serviceTaxonomies()->create(['taxonomy_id' => $taxonomy1->id]);
+        $service1->save();
+
+        $service2->serviceTaxonomies()->create(['taxonomy_id' => $taxonomy2->id]);
+        $service2->save();
+
+        /**
+         * Search 1: service 1 and 2 should not be in the collection
+         */
+        $searchResponse = Service::search('Undeniable Giraffe')->raw();
+
+        $this->assertEquals(1, $searchResponse->total());
+        $this->assertEquals($service1->id, $searchResponse->hits()[0]->document()->content()['id']);
+        $this->assertEquals([], $searchResponse->hits()[0]->document()->content()['collection_categories']);
+
+        $searchResponse = Service::search('Accomplished Possum')->raw();
+
+        $this->assertEquals(1, $searchResponse->total());
+        $this->assertEquals($service2->id, $searchResponse->hits()[0]->document()->content()['id']);
+        $this->assertEquals([], $searchResponse->hits()[0]->document()->content()['collection_categories']);
+
+        // Sync taxonomy 1 to the collection
+        $collection->syncCollectionTaxonomies((new EloquentCollection([$taxonomy1])));
+
+        /**
+         * Search 2: service 1 should be in the collection, service 2 should not
+         */
+        $searchResponse = Service::search('Undeniable Giraffe')->raw();
+
+        $this->assertEquals(1, $searchResponse->total());
+        $this->assertEquals($service1->id, $searchResponse->hits()[0]->document()->content()['id']);
+        $this->assertEquals(['Adventurous Animals'], $searchResponse->hits()[0]->document()->content()['collection_categories']);
+
+        $searchResponse = Service::search('Accomplished Possum')->raw();
+
+        $this->assertEquals(1, $searchResponse->total());
+        $this->assertEquals($service2->id, $searchResponse->hits()[0]->document()->content()['id']);
+        $this->assertEquals([], $searchResponse->hits()[0]->document()->content()['collection_categories']);
+
+        // Sync taxonomy 2 to the collection
+        $collection->syncCollectionTaxonomies((new EloquentCollection([$taxonomy2])));
+
+        $this->assertCount(1, $collection->taxonomies);
+
+        /**
+         * Search 3: service 2 should be in the collection, service 1 should not
+         */
+        $searchResponse = Service::search('Undeniable Giraffe')->raw();
+
+        $this->assertEquals(1, $searchResponse->total());
+        $this->assertEquals($service1->id, $searchResponse->hits()[0]->document()->content()['id']);
+        $this->assertEquals([], $searchResponse->hits()[0]->document()->content()['collection_categories']);
+
+        $searchResponse = Service::search('Accomplished Possum')->raw();
+
+        $this->assertEquals(1, $searchResponse->total());
+        $this->assertEquals($service2->id, $searchResponse->hits()[0]->document()->content()['id']);
+        $this->assertEquals(['Adventurous Animals'], $searchResponse->hits()[0]->document()->content()['collection_categories']);
+    }
+
+    /**
+     * @test
+     */
+    public function updateCollectionTaxonomiesReIndexesRelatedOrganisationEvents()
+    {
+        $event1 = OrganisationEvent::factory()->create([
+            'title' => 'Undeniable Giraffe',
+        ]);
+        $event2 = OrganisationEvent::factory()->create([
+            'title' => 'Accomplished Possum',
+        ]);
+        $collection = Collection::create([
+            'type' => Collection::TYPE_ORGANISATION_EVENT,
+            'slug' => 'adventurous-animals',
+            'name' => 'Adventurous Animals',
+            'meta' => [],
+            'order' => 1,
+        ]);
+        $taxonomy1 = Taxonomy::category()->children()->create([
+            'slug' => 'test-taxonomy-1',
+            'name' => 'Test Taxonomy 1',
+            'order' => 1,
+            'depth' => 1,
+        ]);
+        $taxonomy2 = Taxonomy::category()->children()->create([
+            'slug' => 'test-taxonomy-2',
+            'name' => 'Test Taxonomy 2',
+            'order' => 2,
+            'depth' => 1,
+        ]);
+
+        // Attach events to taxonomies
+        $event1->organisationEventTaxonomies()->create(['taxonomy_id' => $taxonomy1->id]);
+        $event1->save();
+
+        $event2->organisationEventTaxonomies()->create(['taxonomy_id' => $taxonomy2->id]);
+        $event2->save();
+
+        /**
+         * Search 1: event 1 and 2 should not be in the collection
+         */
+        $searchResponse = OrganisationEvent::search('Undeniable Giraffe')->raw();
+
+        $this->assertEquals(1, $searchResponse->total());
+        $this->assertEquals($event1->id, $searchResponse->hits()[0]->document()->content()['id']);
+        $this->assertEquals([], $searchResponse->hits()[0]->document()->content()['collection_categories']);
+
+        $searchResponse = OrganisationEvent::search('Accomplished Possum')->raw();
+
+        $this->assertEquals(1, $searchResponse->total());
+        $this->assertEquals($event2->id, $searchResponse->hits()[0]->document()->content()['id']);
+        $this->assertEquals([], $searchResponse->hits()[0]->document()->content()['collection_categories']);
+
+        // Sync taxonomy 1 to the collection
+        $collection->syncCollectionTaxonomies((new EloquentCollection([$taxonomy1])));
+
+        /**
+         * Search 2: event 1 should be in the collection, event 2 should not
+         */
+        $searchResponse = OrganisationEvent::search('Undeniable Giraffe')->raw();
+
+        $this->assertEquals(1, $searchResponse->total());
+        $this->assertEquals($event1->id, $searchResponse->hits()[0]->document()->content()['id']);
+        $this->assertEquals(['Adventurous Animals'], $searchResponse->hits()[0]->document()->content()['collection_categories']);
+
+        $searchResponse = OrganisationEvent::search('Accomplished Possum')->raw();
+
+        $this->assertEquals(1, $searchResponse->total());
+        $this->assertEquals($event2->id, $searchResponse->hits()[0]->document()->content()['id']);
+        $this->assertEquals([], $searchResponse->hits()[0]->document()->content()['collection_categories']);
+
+        // Sync taxonomy 2 to the collection
+        $collection->syncCollectionTaxonomies((new EloquentCollection([$taxonomy2])));
+
+        $this->assertCount(1, $collection->taxonomies);
+
+        /**
+         * Search 3: event 2 should be in the collection, event 1 should not
+         */
+        $searchResponse = OrganisationEvent::search('Undeniable Giraffe')->raw();
+
+        $this->assertEquals(1, $searchResponse->total());
+        $this->assertEquals($event1->id, $searchResponse->hits()[0]->document()->content()['id']);
+        $this->assertEquals([], $searchResponse->hits()[0]->document()->content()['collection_categories']);
+
+        $searchResponse = OrganisationEvent::search('Accomplished Possum')->raw();
+
+        $this->assertEquals(1, $searchResponse->total());
+        $this->assertEquals($event2->id, $searchResponse->hits()[0]->document()->content()['id']);
+        $this->assertEquals(['Adventurous Animals'], $searchResponse->hits()[0]->document()->content()['collection_categories']);
+    }
+}


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/3633/fix-collection-reindex-issue

- updated all the touchServices methods to use the `searchable` method
- updated `Collection::syncCollectionTaxonomies` so services and events are re-indexed if their taxonomies are added or removed from a collection

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
