### PR TITLE
Updated UK phone regex and stripped spaces

### DIFF
--- a/app/Http/Requests/OrganisationSignUpForm/StoreRequest.php
+++ b/app/Http/Requests/OrganisationSignUpForm/StoreRequest.php
@@ -16,6 +16,7 @@ use App\Rules\UserEmailNotInPendingSignupRequest;
 use App\Rules\UserEmailNotTaken;
 use App\Rules\VideoEmbed;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 
 class StoreRequest extends FormRequest
@@ -224,5 +225,24 @@ class StoreRequest extends FormRequest
             'service.url.url' => '4. Service, Details tab - Please enter a valid web address in the correct format (starting with https:// or http://).',
             'service.contact_email.email' => "4. Service, Additional Info tab - Please enter an email address users can use to contact your {$type} (eg. name@example.com).",
         ];
+    }
+
+    /**
+     * Prepare the data for validation.
+     */
+    protected function prepareForValidation(): void
+    {
+        logger('Before', ['user' => $this->user, 'organisation' => $this->organisation]);
+        $user = $this->user;
+        $user['phone'] = Str::remove(' ', $user['phone']);
+
+        $organisation = $this->organisation;
+        $organisation['phone'] = Str::remove(' ', $organisation['phone']);
+
+        $this->merge([
+            'user' => $user,
+            'organisation' => $organisation,
+        ]);
+        logger('After', ['user' => $this->user, 'organisation' => $this->organisation]);
     }
 }

--- a/app/Http/Requests/OrganisationSignUpForm/StoreRequest.php
+++ b/app/Http/Requests/OrganisationSignUpForm/StoreRequest.php
@@ -232,17 +232,17 @@ class StoreRequest extends FormRequest
      */
     protected function prepareForValidation(): void
     {
-        logger('Before', ['user' => $this->user, 'organisation' => $this->organisation]);
         $user = $this->user;
         $user['phone'] = Str::remove(' ', $user['phone']);
 
         $organisation = $this->organisation;
-        $organisation['phone'] = Str::remove(' ', $organisation['phone']);
+        if ($organisation['phone'] ?? false) {
+            $organisation['phone'] = Str::remove(' ', $organisation['phone']);
+        }
 
         $this->merge([
             'user' => $user,
             'organisation' => $organisation,
         ]);
-        logger('After', ['user' => $this->user, 'organisation' => $this->organisation]);
     }
 }

--- a/app/Rules/UkPhoneNumber.php
+++ b/app/Rules/UkPhoneNumber.php
@@ -32,7 +32,7 @@ class UkPhoneNumber implements ValidationRule
             $fail(__('validation.string'));
         }
 
-        if (preg_match('/^0([1-6][0-9]{8,10}|7[0-9]{9})$/', $value) !== 1) {
+        if (preg_match('/^0([1-6][0-9]{8,10}|7[0-9]{9}|8[0-9]{9})$/', $value) !== 1) {
             $fail($this->message());
         }
     }


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/3647/update-request-won-t-approve-due-to-phone-number-validation-issue

- Added 0800 numbers to valid UK phone number regex
- Added pre-validation method to strip spaces from phone numbers

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
