### PR TITLE
Improved score function for service search

### DIFF
--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -70,7 +70,7 @@ class Page extends Model implements AppliesUpdateRequests
         $contentSections = [];
         foreach ($this->content as $sectionLabel => $sectionContent) {
             $content = [];
-            foreach ($sectionContent['content'] as $i => $contentBlock) {
+            foreach ($sectionContent['content'] ?? [] as $i => $contentBlock) {
                 switch ($contentBlock['type']) {
                     case 'copy':
                         $content[] = $this->makeSearchable($contentBlock['value']);

--- a/app/Search/ElasticSearch/CollectionCategoryQueryBuilder.php
+++ b/app/Search/ElasticSearch/CollectionCategoryQueryBuilder.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare (strict_types=1);
 
 namespace App\Search\ElasticSearch;
 
@@ -25,10 +25,10 @@ class CollectionCategoryQueryBuilder extends ElasticsearchQueryBuilder implement
                 ],
                 'functions' => [
                     [
-                        'field_value_factor' => [
-                            'field' => 'score',
-                            'missing' => 1,
-                            'modifier' => 'ln1p',
+                        'script_score' => [
+                            'script' => [
+                                'source' => "doc['score'].size() == 0 ? 1 : ((doc['score'].value + 1) * 0.1) + 1",
+                            ],
                         ],
                     ],
                 ],

--- a/app/Search/ElasticSearch/CollectionPersonaQueryBuilder.php
+++ b/app/Search/ElasticSearch/CollectionPersonaQueryBuilder.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare (strict_types=1);
 
 namespace App\Search\ElasticSearch;
 
@@ -25,10 +25,10 @@ class CollectionPersonaQueryBuilder extends ElasticsearchQueryBuilder implements
                 ],
                 'functions' => [
                     [
-                        'field_value_factor' => [
-                            'field' => 'score',
-                            'missing' => 1,
-                            'modifier' => 'ln1p',
+                        'script_score' => [
+                            'script' => [
+                                'source' => "doc['score'].size() == 0 ? 1 : ((doc['score'].value + 1) * 0.1) + 1",
+                            ],
                         ],
                     ],
                 ],

--- a/app/Search/ElasticSearch/ServiceQueryBuilder.php
+++ b/app/Search/ElasticSearch/ServiceQueryBuilder.php
@@ -29,7 +29,7 @@ class ServiceQueryBuilder extends ElasticsearchQueryBuilder implements QueryBuil
                     [
                         'script_score' => [
                             'script' => [
-                                'source' => "((doc['score'].value + 1) * 0.1) + 1",
+                                'source' => "doc['score'].size() == 0 ? 1 : ((doc['score'].value + 1) * 0.1) + 1",
                             ],
                         ],
                     ],

--- a/database/factories/ServiceFactory.php
+++ b/database/factories/ServiceFactory.php
@@ -28,8 +28,6 @@ class ServiceFactory extends Factory
             'status' => Service::STATUS_ACTIVE,
             'intro' => mb_substr($this->faker->paragraph(2), 0, 149),
             'description' => $this->faker->paragraph(5),
-            // 'intro' => 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit.',
-            // 'description' => 'Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.',
             'is_free' => true,
             'url' => $this->faker->url(),
             'contact_name' => $this->faker->name(),


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/3659/improve-sutton-search-results

- When searching for a persona there were no service results being returned
- The search score function was creating an error if the service had no score search attribute
- Updated the score function to handle results with no score

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
