### PR TITLE
Added organisation to service update response if organisation changed

### DIFF
--- a/app/Docs/Schemas/Service/UpdateServiceSchema.php
+++ b/app/Docs/Schemas/Service/UpdateServiceSchema.php
@@ -19,6 +19,7 @@ class UpdateServiceSchema extends Schema
                 'name',
                 'slug',
                 'type',
+                'organisation_id',
                 'status',
                 'intro',
                 'description',
@@ -54,6 +55,8 @@ class UpdateServiceSchema extends Schema
                         Service::TYPE_CLUB,
                         Service::TYPE_GROUP
                     ),
+                Schema::string('organisation_id')
+                    ->format(static::FORMAT_UUID),
                 Schema::string('status')
                     ->enum(Service::STATUS_ACTIVE, Service::STATUS_INACTIVE),
                 Schema::integer('score')

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Contracts\AppliesUpdateRequests;
 use App\Emails\Email;
 use App\Http\Requests\Service\UpdateRequest as UpdateServiceRequest;
+use App\Http\Resources\OrganisationResource;
 use App\Models\Mutators\ServiceMutators;
 use App\Models\Relationships\ServiceRelationships;
 use App\Models\Scopes\ServiceScopes;
@@ -327,6 +328,10 @@ class Service extends Model implements AppliesUpdateRequests, Notifiable, HasTax
      */
     public function getData(array $data): array
     {
+        if (isset($data['organisation_id'])) {
+            $data['organisation'] = new OrganisationResource(Organisation::find($data['organisation_id']));
+        }
+
         return $data;
     }
 

--- a/tests/Feature/ServicesTest.php
+++ b/tests/Feature/ServicesTest.php
@@ -4826,7 +4826,7 @@ class ServicesTest extends TestCase
         $response = $this->json('PUT', "/core/v1/services/{$service->id}", $payload);
 
         $response->assertStatus(Response::HTTP_OK);
-        $response->assertJsonFragment(['data' => $payload]);
+        $response->assertJsonFragment($payload);
 
         $updateRequestId = $response->json()['id'];
 
@@ -4881,7 +4881,8 @@ class ServicesTest extends TestCase
         ));
 
         $response->assertStatus(Response::HTTP_OK);
-        $response->assertJsonFragment(['id' => null, 'data' => $payload]);
+        $response->assertJsonFragment(['id' => null]);
+        $response->assertJsonFragment($payload);
     }
 
     /**
@@ -4905,7 +4906,7 @@ class ServicesTest extends TestCase
         $response = $this->json('PUT', "/core/v1/services/{$service->id}", $payload);
 
         $response->assertStatus(Response::HTTP_OK);
-        $response->assertJsonFragment(['data' => $payload]);
+        $response->assertJsonFragment($payload);
 
         $data = UpdateRequest::query()
             ->where('updateable_type', UpdateRequest::EXISTING_TYPE_SERVICE)


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/3648/admin-ui-hangs-when-trying-to-change-the-orgniasation-value-on-a-service

- Updating a service and changing the organisation returned the organisation id but not the organisation object
- Added the organisation object to the update response if the organisation id was being changed

### Development checklist

- [x] Changes have been made to the API?
  - [x] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
