### PR TITLE
Added updateable_type filter to update request index

### DIFF
--- a/app/Docs/Operations/UpdateRequests/IndexUpdateRequestOperation.php
+++ b/app/Docs/Operations/UpdateRequests/IndexUpdateRequestOperation.php
@@ -85,8 +85,27 @@ Entry to filter by:
 EOT
                     )
                     ->schema(Schema::string()),
+                FilterParameter::create(null, 'type')
+                    ->description(
+                        <<<'EOT'
+Type to filter by:
+* Service update: `services`
+* New Service: `new_service_created_by_global_admin`
+* Location: `locations`
+* Service location: `service_locations`
+* Organisation update: `organisations`
+* New Organisation: `new_organisation_created_by_global_admin`
+* Organisation sign up form: `organisation_sign_up_form`
+* Event update: `organisation_events`
+* New Event: `new_organisation_event_created_by_org_admin`
+* Page update: `pages`
+* New Page: `new_page`
+* Referral: `referrals`
+EOT
+                    )
+                    ->schema(Schema::string()),
                 IncludeParameter::create(null, ['user']),
-                SortParameter::create(null, ['entry', 'created_at'], '-created_at')
+                SortParameter::create(null, ['entry','created_at'], '-created_at')
             )
             ->responses(
                 Response::ok()->content(

--- a/app/Http/Controllers/Core/V1/UpdateRequestController.php
+++ b/app/Http/Controllers/Core/V1/UpdateRequestController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Core\V1;
 use App\Events\EndpointHit;
 use App\Http\Controllers\Controller;
 use App\Http\Filters\UpdateRequest\EntryFilter;
+use App\Http\Filters\UpdateRequest\TypeFilter;
 use App\Http\Requests\UpdateRequest\DestroyRequest;
 use App\Http\Requests\UpdateRequest\IndexRequest;
 use App\Http\Requests\UpdateRequest\ShowRequest;
@@ -44,6 +45,7 @@ class UpdateRequestController extends Controller
                 AllowedFilter::scope('location_id'),
                 AllowedFilter::scope('organisation_id'),
                 AllowedFilter::custom('entry', new EntryFilter()),
+                AllowedFilter::custom('type', new TypeFilter()),
             ])
             ->allowedIncludes(['user'])
             ->allowedSorts([

--- a/app/Http/Filters/UpdateRequest/TypeFilter.php
+++ b/app/Http/Filters/UpdateRequest/TypeFilter.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Filters\UpdateRequest;
+
+use App\Models\UpdateRequest;
+use Illuminate\Database\Eloquent\Builder;
+use Spatie\QueryBuilder\Filters\Filter;
+
+class TypeFilter implements Filter
+{
+    public function __invoke(Builder $query, $value, string $property): Builder
+    {
+        if ($value === UpdateRequest::NEW_TYPE_SERVICE_ORG_ADMIN || $value == UpdateRequest::NEW_TYPE_SERVICE_GLOBAL_ADMIN) {
+            $value = [
+                UpdateRequest::NEW_TYPE_SERVICE_ORG_ADMIN,
+                UpdateRequest::NEW_TYPE_SERVICE_GLOBAL_ADMIN,
+            ];
+        }
+
+        return $query->whereIn('updateable_type', (array)$value);
+    }
+}


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/3745/filter-update-requests-by-entity-type

- Added filter to update request index to filter results by `updateable_type`

### Development checklist

- [x] Changes have been made to the API?
  - [x] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
