### PR TITLE
Fixed search ServiceEloquentMapper relationships loading

### DIFF
--- a/app/Search/ElasticSearch/ServiceEloquentMapper.php
+++ b/app/Search/ElasticSearch/ServiceEloquentMapper.php
@@ -24,7 +24,7 @@ class ServiceEloquentMapper implements EloquentMapper
         $page = page($page);
         $perPage = per_page($perPage);
 
-        $esQuery->load(['serviceLocations'], Service::class);
+        $esQuery->load(['serviceLocations.location'], Service::class);
 
         $queryRequest = $esQuery->buildSearchRequest()->toArray();
 

--- a/tests/Feature/Search/ServiceTest.php
+++ b/tests/Feature/Search/ServiceTest.php
@@ -33,7 +33,10 @@ class ServiceTest extends TestCase implements UsesElasticsearch
 
     public function test_guest_can_search(): void
     {
-        Service::factory()->create(['name' => 'This is a test']);
+        $service = Service::factory()->create(['name' => 'This is a test']);
+        $serviceLocation = ServiceLocation::factory()->create([
+            'service_id' => $service->id,
+        ]);
 
         sleep(1);
 
@@ -93,7 +96,11 @@ class ServiceTest extends TestCase implements UsesElasticsearch
                     'last_modified_at',
                     'created_at',
                     'updated_at',
-                    'service_locations',
+                    'service_locations' => [
+                        [
+                            'location',
+                        ],
+                    ],
                     'cqc_location_id',
                 ],
             ],

--- a/tests/Feature/ServicesTest.php
+++ b/tests/Feature/ServicesTest.php
@@ -5064,24 +5064,6 @@ class ServicesTest extends TestCase
         $response = $this->json('DELETE', "/core/v1/services/{$service->id}");
 
         $response->assertStatus(Response::HTTP_FORBIDDEN);
-
-        // $this->assertDatabaseHas((new Service())->getTable(), ['id' => $service->id]);
-
-        // //Then an update request should be created for the new service
-        // $updateRequest = UpdateRequest::query()
-        //     ->where('updateable_type', UpdateRequest::DESTROY_TYPE_SERVICE_GLOBAL_ADMIN)
-        //     ->where('updateable_id', $service->id)
-        //     ->firstOrFail();
-
-        // // Simulate frontend check by making call with UpdateRequest ID.
-
-        // Passport::actingAs(User::factory()->create()->makeSuperAdmin());
-
-        // $response = $this->json('PUT', "/core/v1/update-requests/{$updateRequest->id}/approve");
-
-        // $response->assertStatus(Response::HTTP_OK);
-
-        // $this->assertDatabaseMissing((new Service())->getTable(), ['id' => $service->id]);
     }
 
     /**


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/3708/maps-view-is-not-loading-on-search-results

- `Search\ServiceEloquentMapper` was loading the `serviceLocations` relationship
- Changed the relationship loading to `serviceLocations.location` so loading the `location` object

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
