### PR TITLE
Added video content type tpo page content

### DIFF
--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -78,6 +78,9 @@ class Page extends Model implements AppliesUpdateRequests
                     case 'cta':
                         $content[] = $this->makeSearchable($contentBlock['title'] . ' ' . $contentBlock['description']);
                         break;
+                    case 'video':
+                        $content[] = $this->makeSearchable($contentBlock['title']);
+                        break;
                     default:
                         break;
                 }

--- a/app/Rules/PageContent.php
+++ b/app/Rules/PageContent.php
@@ -4,6 +4,7 @@ namespace App\Rules;
 
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Support\Str;
 
 class PageContent implements ValidationRule
 {
@@ -50,8 +51,7 @@ class PageContent implements ValidationRule
                 $fail('Page content is required for introduction');
             }
 
-        }
-        if ($value['type'] === 'cta') {
+        } elseif ($value['type'] === 'cta') {
             if (empty($value['title']) || !is_string($value['title'])) {
                 $fail('Call to action title is required');
             }
@@ -67,7 +67,30 @@ class PageContent implements ValidationRule
             if (!empty($value['url']) && filter_var($value['url'], FILTER_VALIDATE_URL) === false) {
                 $fail('Call to action link must be a valid URL');
             }
+        } elseif ($value['type'] === 'video') {
+            if (empty($value['title']) || !is_string($value['title'])) {
+                $fail('Video title is required');
+            }
 
+            if (empty($value['url']) || !is_string($value['url'])) {
+                $fail('Video url is required');
+            }
+
+            if (!empty($value['url'])) {
+                if (filter_var($value['url'], FILTER_VALIDATE_URL) === false) {
+                    $fail('Video url must be a valid URL');
+                }
+
+                if (!Str::startsWith($value['url'], [
+                    'https://www.youtube.com',
+                    'https://player.vimeo.com',
+                    'https://vimeo.com',
+                ])) {
+                    $fail('The video url must be provided by either YouTube or Vimeo.');
+                }
+            }
+        } else {
+            $fail('Invalid content type');
         }
     }
 }

--- a/tests/Feature/PagesTest.php
+++ b/tests/Feature/PagesTest.php
@@ -2084,6 +2084,7 @@ class PagesTest extends TestCase
 
         $parentPage = Page::factory()->create();
 
+        // Missing title
         $data = [
             'title' => $this->faker->sentence(),
             'excerpt' => trim(substr($this->faker->paragraph(2), 0, 149)),
@@ -2111,6 +2112,7 @@ class PagesTest extends TestCase
 
         $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
+        // Missing description
         $data = [
             'title' => $this->faker->sentence(),
             'excerpt' => trim(substr($this->faker->paragraph(2), 0, 149)),
@@ -2138,6 +2140,7 @@ class PagesTest extends TestCase
 
         $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
+        // Missing button text
         $data = [
             'title' => $this->faker->sentence(),
             'excerpt' => trim(substr($this->faker->paragraph(2), 0, 149)),
@@ -2165,6 +2168,7 @@ class PagesTest extends TestCase
 
         $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
+        // Invalid URL
         $data = [
             'title' => $this->faker->sentence(),
             'excerpt' => trim(substr($this->faker->paragraph(2), 0, 149)),
@@ -2234,6 +2238,49 @@ class PagesTest extends TestCase
         $response = $this->json('POST', '/core/v1/pages', $data);
 
         $response->assertStatus(Response::HTTP_OK);
+    }
+
+    /**
+     * @test
+     */
+    public function createInformationPageWithVideoAsContentAdmin200(): void
+    {
+        /**
+         * @var \App\Models\User $user
+         */
+        $user = User::factory()->create();
+        $user->makeContentAdmin();
+
+        Passport::actingAs($user);
+
+        $parentPage = Page::factory()->create();
+
+        $data = [
+            'title' => $this->faker->sentence(),
+            'excerpt' => trim(substr($this->faker->paragraph(2), 0, 149)),
+            'content' => [
+                'introduction' => [
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
+                        [
+                            'type' => 'video',
+                            'title' => $this->faker->sentence(),
+                            'url' => 'https://www.youtube.com/watch?v=dummy_id',
+                        ],
+                    ],
+                ],
+            ],
+            'parent_id' => $parentPage->id,
+            'page_type' => 'information',
+        ];
+        $response = $this->json('POST', '/core/v1/pages', $data);
+
+        $response->assertStatus(Response::HTTP_OK);
+
+        $response->assertJsonFragment($data);
     }
 
     /**
@@ -2318,6 +2365,86 @@ class PagesTest extends TestCase
         $response = $this->json('POST', '/core/v1/pages', $data);
 
         $response->assertStatus(Response::HTTP_OK);
+    }
+
+    /**
+     * @test
+     */
+    public function createLandingPageWithVideosAsContentAdmin200(): void
+    {
+        /**
+         * @var \App\Models\User $user
+         */
+        $user = User::factory()->create();
+        $user->makeContentAdmin();
+
+        Passport::actingAs($user);
+
+        $data = [
+            'title' => $this->faker->sentence(),
+            'excerpt' => trim(substr($this->faker->paragraph(2), 0, 149)),
+            'content' => [
+                'introduction' => [
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
+                        [
+                            'type' => 'video',
+                            'title' => $this->faker->sentence(),
+                            'url' => 'https://www.youtube.com/watch?v=dummy_id',
+                        ],
+                    ],
+                ],
+                'about' => [
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
+                        [
+                            'type' => 'video',
+                            'title' => $this->faker->sentence(),
+                            'url' => 'https://www.youtube.com/watch?v=dummy_id',
+                        ],
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
+                    ],
+                ],
+                'info_pages' => [
+                    'title' => $this->faker->sentence(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
+                        [
+                            'type' => 'video',
+                            'title' => $this->faker->sentence(),
+                            'url' => 'https://www.youtube.com/watch?v=dummy_id',
+                        ],
+                    ],
+                ],
+                'collections' => [
+                    'title' => $this->faker->sentence(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
+                    ],
+                ],
+            ],
+            'page_type' => Page::PAGE_TYPE_LANDING,
+        ];
+        $response = $this->json('POST', '/core/v1/pages', $data);
+
+        $response->assertStatus(Response::HTTP_OK);
+
+        $response->assertJsonFragment($data);
     }
 
     /**
@@ -2904,6 +3031,28 @@ class PagesTest extends TestCase
         $data = [
             'title' => 'New Title',
             'enabled' => true,
+            'content' => [
+                'introduction' => [
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
+                        [
+                            'type' => 'cta',
+                            'title' => $this->faker->sentence(),
+                            'description' => $this->faker->realText(),
+                            'url' => $this->faker->url(),
+                            'buttonText' => $this->faker->words(3, true),
+                        ],
+                        [
+                            'type' => 'video',
+                            'title' => $this->faker->sentence(),
+                            'url' => 'https://www.youtube.com/watch?v=dummy_id',
+                        ],
+                    ],
+                ],
+            ],
         ];
 
         $response = $this->json('PUT', '/core/v1/pages/' . $page->id, $data);
@@ -2938,6 +3087,10 @@ class PagesTest extends TestCase
             'title' => 'New Title',
             'enabled' => true,
         ]);
+
+        $response = $this->json('GET', '/core/v1/pages/' . $page->id);
+
+        $response->assertJsonFragment($data);
     }
 
     /**


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/3308/allow-videos-to-be-embeded-within-page-content

- Added `video` content type for Page `content` field

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
