### PR TITLE
Remove requirement for email or phone on organisations

### DIFF
--- a/app/Http/Requests/Organisation/UpdateRequest.php
+++ b/app/Http/Requests/Organisation/UpdateRequest.php
@@ -56,16 +56,12 @@ class UpdateRequest extends FormRequest
                 'url',
                 'max:255'],
             'email' => [
-                new NullableIf(function () {
-                    return $this->user()->isGlobalAdmin() || $this->input('phone', $this->organisation->phone) !== null;
-                }),
+                'nullable',
                 'email',
                 'max:255',
             ],
             'phone' => [
-                new NullableIf(function () {
-                    return $this->user()->isGlobalAdmin() || $this->input('email', $this->organisation->email) !== null;
-                }),
+                'nullable',
                 'string',
                 'min:1',
                 'max:255',

--- a/app/Http/Requests/OrganisationSignUpForm/StoreRequest.php
+++ b/app/Http/Requests/OrganisationSignUpForm/StoreRequest.php
@@ -80,14 +80,14 @@ class StoreRequest extends FormRequest
             'organisation.description' => ['required_without:organisation.id', 'nullable', 'string', 'min:1', 'max:10000'],
             'organisation.url' => ['required_without:organisation.id', 'nullable', 'url', 'max:255'],
             'organisation.email' => [
+                'sometimes',
                 'nullable',
-                'required_without_all:organisation.id,organisation.phone',
                 'email',
                 'max:255',
             ],
             'organisation.phone' => [
+                'sometimes',
                 'nullable',
-                'required_without_all:organisation.id,organisation.email',
                 'string',
                 'min:1',
                 'max:255',
@@ -212,8 +212,8 @@ class StoreRequest extends FormRequest
             'organisation.description.required' => '3. Organisation - Please enter a one-line summary of the organisation.',
             'organisation.url.required' => '3. Organisation - Please enter a valid web address in the correct format (starting with https:// or http://).',
             'organisation.url.url' => '3. Organisation - Please enter a valid web address in the correct format (starting with https:// or http://).',
-            'organisation.email.required_without' => '3. Organisation - Please enter a public email address and/or a public phone number.',
-            'organisation.phone.required_without' => '3. Organisation - Please enter a public phone number and/or public email address.',
+            'organisation.email.required_without_all' => '3. Organisation - Please enter a public email address and/or a public phone number.',
+            'organisation.phone.required_without_all' => '3. Organisation - Please enter a public phone number and/or public email address.',
             'organisation.email.email' => '3. Organisation - Please enter the email for your organisation (eg. name@example.com).',
 
             'service.slug.required' => "4. Service, Details tab - Please enter the name of your {$type}.",

--- a/tests/Feature/OrganisationsTest.php
+++ b/tests/Feature/OrganisationsTest.php
@@ -994,7 +994,7 @@ class OrganisationsTest extends TestCase
     /**
      * @test
      */
-    public function organisation_admin_cannot_update_with_no_form_of_contact(): void
+    public function organisation_admin_can_update_with_no_form_of_contact(): void
     {
         $organisation = Organisation::factory()->create([
             'email' => 'info@test-org.example.com',
@@ -1013,7 +1013,7 @@ class OrganisationsTest extends TestCase
             'phone' => null,
         ]);
 
-        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $response->assertStatus(Response::HTTP_OK);
     }
 
     /**


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/3941/org-phone-required-on-public-registration

- Removed requirement for either an email or phone field on organisation registration workflow

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
