### PR TITLE
Set text limits on all the description fields

### DIFF
--- a/app/Http/Requests/Organisation/StoreRequest.php
+++ b/app/Http/Requests/Organisation/StoreRequest.php
@@ -9,6 +9,8 @@ use App\Models\SocialMedia;
 use App\Models\Taxonomy;
 use App\Rules\FileIsMimeType;
 use App\Rules\FileIsPendingAssignment;
+use App\Rules\MarkdownMaxLength;
+use App\Rules\MarkdownMinLength;
 use App\Rules\RootTaxonomyIs;
 use App\Rules\Slug;
 use App\Rules\UkPhoneNumber;
@@ -46,7 +48,12 @@ class StoreRequest extends FormRequest
                 new Slug(),
             ],
             'name' => ['required', 'string', 'min:1', 'max:255'],
-            'description' => ['required', 'string', 'min:1', 'max:10000'],
+            'description' => [
+                'required',
+                'string',
+                new MarkdownMinLength(1),
+                new MarkdownMaxLength(10000, 'Description tab - The long description must be 10000 characters or fewer.'),
+            ],
             'url' => ['present', 'nullable', 'url', 'max:255'],
             'email' => ['present', 'nullable', 'email', 'max:255'],
             'phone' => [

--- a/app/Http/Requests/Organisation/UpdateRequest.php
+++ b/app/Http/Requests/Organisation/UpdateRequest.php
@@ -10,6 +10,8 @@ use App\Models\Taxonomy;
 use App\Rules\CanUpdateCategoryTaxonomyRelationships;
 use App\Rules\FileIsMimeType;
 use App\Rules\FileIsPendingAssignment;
+use App\Rules\MarkdownMaxLength;
+use App\Rules\MarkdownMinLength;
 use App\Rules\RootTaxonomyIs;
 use App\Rules\Slug;
 use App\Rules\UkPhoneNumber;
@@ -47,7 +49,11 @@ class UpdateRequest extends FormRequest
                 new Slug(),
             ],
             'name' => ['string', 'min:1', 'max:255'],
-            'description' => ['string', 'min:1', 'max:10000'],
+            'description' => [
+                'string',
+                new MarkdownMinLength(1),
+                new MarkdownMaxLength(10000, 'Description tab - The long description must be 10000 characters or fewer.'),
+            ],
             'url' => [
                 'nullable',
                 'url',

--- a/app/Http/Requests/OrganisationEvent/StoreRequest.php
+++ b/app/Http/Requests/OrganisationEvent/StoreRequest.php
@@ -62,7 +62,7 @@ class StoreRequest extends FormRequest
                 'required',
                 'string',
                 new MarkdownMinLength(1),
-                new MarkdownMaxLength(3000, 'Description tab - The long description must be 3000 characters or fewer.'),
+                new MarkdownMaxLength(10000, 'Description tab - The long description must be 10000 characters or fewer.'),
             ],
             'is_free' => ['required', 'boolean'],
             'fees_text' => [

--- a/app/Http/Requests/OrganisationEvent/UpdateRequest.php
+++ b/app/Http/Requests/OrganisationEvent/UpdateRequest.php
@@ -68,7 +68,7 @@ class UpdateRequest extends FormRequest
             'description' => [
                 'string',
                 new MarkdownMinLength(1),
-                new MarkdownMaxLength(3000, 'Description tab - The long description must be 3000 characters or fewer.'),
+                new MarkdownMaxLength(10000, 'Description tab - The long description must be 10000 characters or fewer.'),
             ],
             'is_free' => ['boolean'],
             'fees_text' => ['nullable', 'string', 'min:1', 'max:255', 'required_if:is_free,false'],

--- a/app/Http/Requests/OrganisationSignUpForm/StoreRequest.php
+++ b/app/Http/Requests/OrganisationSignUpForm/StoreRequest.php
@@ -77,7 +77,13 @@ class StoreRequest extends FormRequest
                 new Slug(),
             ],
             'organisation.name' => ['required_without:organisation.id', 'nullable', 'string', 'min:1', 'max:255'],
-            'organisation.description' => ['required_without:organisation.id', 'nullable', 'string', 'min:1', 'max:10000'],
+            'organisation.description' => [
+                'required_without:organisation.id',
+                'nullable',
+                'string',
+                new MarkdownMinLength(1),
+                new MarkdownMaxLength(10000, 'Description tab - The long description must be 10000 characters or fewer.'),
+            ],
             'organisation.url' => ['sometimes', 'nullable', 'url', 'max:255'],
             'organisation.email' => [
                 'sometimes',


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/4099/increase-event-description-char-limit-to-10k

- Set limit for organisation description to 10000 characters
- Set limit for organisation event description to 10000 characters
- Set limit for service description to 3000 characters

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
