### PR TITLE
Revised character limits and set in config

### DIFF
--- a/app/Http/Controllers/Core/V1/Service/ImportController.php
+++ b/app/Http/Controllers/Core/V1/Service/ImportController.php
@@ -140,7 +140,7 @@ class ImportController extends Controller
                     ),
                 ],
                 'intro' => ['required', 'string', 'min:1', 'max:300'],
-                'description' => ['required', 'string', new MarkdownMinLength(1), new MarkdownMaxLength(1600)],
+                'description' => ['required', 'string', new MarkdownMinLength(1), new MarkdownMaxLength(config('local.service_description_max_chars'))],
                 'wait_time' => ['present', 'nullable', Rule::in([
                     Service::WAIT_TIME_ONE_WEEK,
                     Service::WAIT_TIME_TWO_WEEKS,

--- a/app/Http/Requests/Organisation/StoreRequest.php
+++ b/app/Http/Requests/Organisation/StoreRequest.php
@@ -52,7 +52,7 @@ class StoreRequest extends FormRequest
                 'required',
                 'string',
                 new MarkdownMinLength(1),
-                new MarkdownMaxLength(10000, 'Description tab - The long description must be 10000 characters or fewer.'),
+                new MarkdownMaxLength(config('local.organisation_description_max_chars'), 'Description tab - The long description must be ' . config('local.organisation_description_max_chars') . ' characters or fewer.'),
             ],
             'url' => ['present', 'nullable', 'url', 'max:255'],
             'email' => ['present', 'nullable', 'email', 'max:255'],

--- a/app/Http/Requests/Organisation/UpdateRequest.php
+++ b/app/Http/Requests/Organisation/UpdateRequest.php
@@ -52,7 +52,7 @@ class UpdateRequest extends FormRequest
             'description' => [
                 'string',
                 new MarkdownMinLength(1),
-                new MarkdownMaxLength(10000, 'Description tab - The long description must be 10000 characters or fewer.'),
+                new MarkdownMaxLength(config('local.organisation_description_max_chars'), 'Description tab - The long description must be ' . config('local.organisation_description_max_chars') . ' characters or fewer.'),
             ],
             'url' => [
                 'nullable',

--- a/app/Http/Requests/OrganisationEvent/StoreRequest.php
+++ b/app/Http/Requests/OrganisationEvent/StoreRequest.php
@@ -62,7 +62,7 @@ class StoreRequest extends FormRequest
                 'required',
                 'string',
                 new MarkdownMinLength(1),
-                new MarkdownMaxLength(10000, 'Description tab - The long description must be 10000 characters or fewer.'),
+                new MarkdownMaxLength(config('local.event_description_max_chars'), 'Description tab - The long description must be ' . config('local.event_description_max_chars') . ' characters or fewer.'),
             ],
             'is_free' => ['required', 'boolean'],
             'fees_text' => [

--- a/app/Http/Requests/OrganisationEvent/UpdateRequest.php
+++ b/app/Http/Requests/OrganisationEvent/UpdateRequest.php
@@ -68,7 +68,7 @@ class UpdateRequest extends FormRequest
             'description' => [
                 'string',
                 new MarkdownMinLength(1),
-                new MarkdownMaxLength(10000, 'Description tab - The long description must be 10000 characters or fewer.'),
+                new MarkdownMaxLength(config('local.event_description_max_chars'), 'Description tab - The long description must be ' . config('local.event_description_max_chars') . ' characters or fewer.'),
             ],
             'is_free' => ['boolean'],
             'fees_text' => ['nullable', 'string', 'min:1', 'max:255', 'required_if:is_free,false'],

--- a/app/Http/Requests/OrganisationSignUpForm/StoreRequest.php
+++ b/app/Http/Requests/OrganisationSignUpForm/StoreRequest.php
@@ -82,7 +82,7 @@ class StoreRequest extends FormRequest
                 'nullable',
                 'string',
                 new MarkdownMinLength(1),
-                new MarkdownMaxLength(10000, 'Description tab - The long description must be 10000 characters or fewer.'),
+                new MarkdownMaxLength(config('local.organisation_description_max_chars'), 'Description tab - The long description must be ' . config('local.organisation_description_max_chars') . ' characters or fewer.'),
             ],
             'organisation.url' => ['sometimes', 'nullable', 'url', 'max:255'],
             'organisation.email' => [
@@ -127,7 +127,7 @@ class StoreRequest extends FormRequest
                 'required',
                 'string',
                 new MarkdownMinLength(1),
-                new MarkdownMaxLength(3000),
+                new MarkdownMaxLength(config('local.service_description_max_chars'), 'Description tab - The long description must be ' . config('local.service_description_max_chars') . ' characters or fewer.'),
             ],
             'service.wait_time' => ['sometimes', 'present', 'nullable', Rule::in([
                 Service::WAIT_TIME_ONE_WEEK,
@@ -157,7 +157,7 @@ class StoreRequest extends FormRequest
                 'required_with:service.useful_infos.*',
                 'string',
                 new MarkdownMinLength(1),
-                new MarkdownMaxLength(10000),
+                new MarkdownMaxLength(config('local.useful_info_description_max_chars')),
             ],
             'service.useful_infos.*.order' => [
                 'required_with:service.useful_infos.*',

--- a/app/Http/Requests/Service/StoreRequest.php
+++ b/app/Http/Requests/Service/StoreRequest.php
@@ -85,7 +85,7 @@ class StoreRequest extends FormRequest
                 'required',
                 'string',
                 new MarkdownMinLength(1),
-                new MarkdownMaxLength(3000, 'Description tab - The long description must be 3000 characters or fewer.'),
+                new MarkdownMaxLength(config('local.service_description_max_chars'), 'Description tab - The long description must be ' . config('local.service_description_max_chars') . ' characters or fewer.'),
             ],
             'wait_time' => ['present', 'nullable', Rule::in([
                 Service::WAIT_TIME_ONE_WEEK,
@@ -188,7 +188,7 @@ class StoreRequest extends FormRequest
             'useful_infos' => ['present', 'array'],
             'useful_infos.*' => ['array'],
             'useful_infos.*.title' => ['required_with:useful_infos.*', 'string', 'min:1', 'max:255'],
-            'useful_infos.*.description' => ['required_with:useful_infos.*', 'string', new MarkdownMinLength(1), new MarkdownMaxLength(1000)],
+            'useful_infos.*.description' => ['required_with:useful_infos.*', 'string', new MarkdownMinLength(1), new MarkdownMaxLength(config('local.useful_info_description_max_chars'))],
             'useful_infos.*.order' => ['required_with:useful_infos.*', 'integer', 'min:1', new InOrder(array_pluck_multi($this->useful_infos, 'order'))],
 
             'offerings' => ['present', 'array'],

--- a/app/Http/Requests/Service/UpdateRequest.php
+++ b/app/Http/Requests/Service/UpdateRequest.php
@@ -100,7 +100,7 @@ class UpdateRequest extends FormRequest
             'description' => [
                 'string',
                 new MarkdownMinLength(1),
-                new MarkdownMaxLength(3000, 'Description tab - The long description must be 3000 characters or fewer.'),
+                new MarkdownMaxLength(config('local.service_description_max_chars'), 'Description tab - The long description must be ' . config('local.service_description_max_chars') . ' characters or fewer.'),
             ],
             'wait_time' => [
                 'nullable',
@@ -218,7 +218,7 @@ class UpdateRequest extends FormRequest
             'useful_infos' => ['array'],
             'useful_infos.*' => ['array'],
             'useful_infos.*.title' => ['required_with:useful_infos.*', 'string', 'min:1', 'max:255'],
-            'useful_infos.*.description' => ['required_with:useful_infos.*', 'string', new MarkdownMinLength(1), new MarkdownMaxLength(1000)],
+            'useful_infos.*.description' => ['required_with:useful_infos.*', 'string', new MarkdownMinLength(1), new MarkdownMaxLength(config('local.useful_info_description_max_chars'))],
             'useful_infos.*.order' => [
                 'required_with:useful_infos.*',
                 'integer',

--- a/app/Rules/PageContent.php
+++ b/app/Rules/PageContent.php
@@ -40,12 +40,20 @@ class PageContent implements ValidationRule
         // Immediately fail if the value is not an array.
         if (!is_array($value)) {
             $fail(__('validation.array'));
+
+            return;
         }
 
         if ($value['type'] === 'copy') {
             if (!array_key_exists('value', $value)) {
                 $fail('Invalid format for content');
+
+                return;
             }
+
+            $validateMarkdown = new MarkdownMaxLength(config('local.page_copy_max_chars'), 'Description tab - The page content must be ' . config('local.page_copy_max_chars') . ' characters or fewer.');
+
+            $validateMarkdown->validate($attribute, $value['value'], fn ($msg) => $fail($msg));
 
             if (($this->pageType === 'landing' && mb_strpos($attribute, 'introduction') && empty($value['value']))) {
                 $fail('Page content is required for introduction');

--- a/config/local.php
+++ b/config/local.php
@@ -68,8 +68,34 @@ return [
         150,
         350,
     ],
+
     /**
      * The request api rate limit per minute per user / IP.
      */
     'api_rate_limit' => env('API_RATE_LIMIT', 300),
+
+    /**
+     * Organisation description character limit.
+     */
+    'organisation_description_max_chars' => env('ORG_DESCRIPTION_MAX_CHARS', 3000),
+
+    /**
+     * Service description character limit.
+     */
+    'service_description_max_chars' => env('SERVICE_DESCRIPTION_MAX_CHARS', 10000),
+
+    /**
+     * Useful Info description character limit.
+     */
+    'useful_info_description_max_chars' => env('USEFUL_INFO_DESCRIPTION_MAX_CHARS', 1000),
+
+    /**
+     * Organisation Event description character limit.
+     */
+    'event_description_max_chars' => env('EVENT_DESCRIPTION_MAX_CHARS', 10000),
+
+    /**
+     * Page copy character limit.
+     */
+    'page_copy_max_chars' => env('PAGE_COPY_MAX_CHARS', 60000),
 ];

--- a/tests/Feature/PagesTest.php
+++ b/tests/Feature/PagesTest.php
@@ -1176,6 +1176,22 @@ class PagesTest extends TestCase
             ],
         ])->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
+        // Exceeds max characters for 'copy' content type
+        $this->json('POST', '/core/v1/pages', [
+            'title' => $this->faker->sentence(),
+            'excerpt' => str_pad($this->faker->paragraph(2), 151, 'words '),
+            'content' => [
+                'introduction' => [
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => implode(' ', array_fill(0, config('local.page_copy_max_chars') + 1, 'test')),
+                        ],
+                    ],
+                ],
+            ],
+        ])->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+
         // Invalid parent id
         $this->json('POST', '/core/v1/pages', [
             'title' => $this->faker->sentence(),


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/4099/increase-event-description-char-limit-to-10k

- Set organisation description character limit to 3000
- Set service description character limit to 10000
- Set organisation event description character limit to 10000
- Set useful info description character limit to 1000
- Set page copy character limit to 60000
- Moved all limits into the config so they can be set by environment variables

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [ ] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
