### PR TITLE
Refactored page resource, added ancestors key

### DIFF
--- a/app/Docs/Schemas/Page/PageListItemSchema.php
+++ b/app/Docs/Schemas/Page/PageListItemSchema.php
@@ -19,7 +19,6 @@ class PageListItemSchema extends Schema
                 Schema::string('slug'),
                 Schema::string('title'),
                 Schema::string('excerpt'),
-                Schema::string('content'),
                 Schema::integer('order'),
                 Schema::boolean('enabled'),
                 Schema::string('page_type')

--- a/app/Docs/Schemas/Page/PageSchema.php
+++ b/app/Docs/Schemas/Page/PageSchema.php
@@ -34,6 +34,8 @@ class PageSchema extends Schema
                 PageListItemSchema::create('parent'),
                 Schema::array('children')
                     ->items(PageListItemSchema::create()),
+                Schema::array('ancestors')
+                    ->items(PageListItemSchema::create()),
                 Schema::array('collection_categories')
                     ->items(CollectionCategorySchema::create()),
                 Schema::array('collection_personas')

--- a/app/Http/Controllers/Core/V1/PageController.php
+++ b/app/Http/Controllers/Core/V1/PageController.php
@@ -49,6 +49,7 @@ class PageController extends Controller
             ->allowedIncludes([
                 'parent',
                 'children',
+                'ancestors',
                 AllowedInclude::relationship('landingPageAncestors', 'landingPageAncestors'),
             ])
             ->allowedFilters([
@@ -82,7 +83,7 @@ class PageController extends Controller
 
         event(EndpointHit::onCreate($request, "Created page [{$entity->id}]", $entity));
 
-        $entity->load('landingPageAncestors', 'parent', 'children', 'collectionCategories', 'collectionPersonas');
+        $entity->load('landingPageAncestors', 'parent', 'children', 'ancestors', 'collectionCategories', 'collectionPersonas');
 
         return new PageResource($entity);
     }
@@ -93,7 +94,7 @@ class PageController extends Controller
     public function show(ShowRequest $request, Page $page): PageResource
     {
         $baseQuery = Page::query()
-            ->with(['landingPageAncestors', 'parent', 'children', 'collectionCategories', 'collectionPersonas'])
+            ->with(['landingPageAncestors', 'parent', 'children', 'ancestors', 'collectionCategories', 'collectionPersonas'])
             ->where('id', $page->id);
 
         $page = QueryBuilder::for($baseQuery)

--- a/app/Http/Resources/PageResource.php
+++ b/app/Http/Resources/PageResource.php
@@ -23,7 +23,19 @@ class PageResource extends JsonResource
             'enabled' => $this->enabled,
             'page_type' => $this->page_type,
             'image' => new FileResource($this->image),
-            'parent' => new static($this->whenLoaded('parent')),
+            'parent' => $this->whenLoaded('parent', function () {
+                return $this->parent ? [
+                    'id' => $this->parent->id,
+                    'title' => $this->parent->title,
+                    'slug' => $this->parent->slug,
+                    'excerpt' => $this->parent->excerpt,
+                    'order' => $this->parent->order,
+                    'enabled' => $this->parent->enabled,
+                    'page_type' => $this->parent->page_type,
+                    'created_at' => $this->parent->created_at->format(CarbonImmutable::ISO8601),
+                    'updated_at' => $this->parent->updated_at->format(CarbonImmutable::ISO8601),
+                ] : null;
+            }),
             'children' => $this->whenLoaded('children', function () {
                 return $this->children->map(function ($child) {
                     return [

--- a/app/Http/Resources/PageResource.php
+++ b/app/Http/Resources/PageResource.php
@@ -18,16 +18,55 @@ class PageResource extends JsonResource
             'title' => $this->title,
             'slug' => $this->slug,
             'excerpt' => $this->excerpt,
-            'content' => $this->content,
+            'content' => $this->when(request()->routeIs('core.v1.pages.store', 'core.v1.pages.show', 'core.v1.pages.update'), $this->content),
             'order' => $this->order,
             'enabled' => $this->enabled,
             'page_type' => $this->page_type,
             'image' => new FileResource($this->image),
-            'landing_page' => new static($this->whenLoaded('landingPageAncestors', function () {
-                return $this->landingPage;
-            })),
             'parent' => new static($this->whenLoaded('parent')),
-            'children' => static::collection($this->whenLoaded('children')),
+            'children' => $this->whenLoaded('children', function () {
+                return $this->children->map(function ($child) {
+                    return [
+                        'id' => $child->id,
+                        'title' => $child->title,
+                        'slug' => $child->slug,
+                        'excerpt' => $child->excerpt,
+                        'order' => $child->order,
+                        'enabled' => $child->enabled,
+                        'page_type' => $child->page_type,
+                        'created_at' => $child->created_at->format(CarbonImmutable::ISO8601),
+                        'updated_at' => $child->updated_at->format(CarbonImmutable::ISO8601),
+                    ];
+                });
+            }),
+            'ancestors' => $this->whenLoaded('ancestors', function () {
+                return static::defaultOrder()->ancestorsOf($this->id)->map(function ($ancestor) {
+                    return [
+                        'id' => $ancestor->id,
+                        'title' => $ancestor->title,
+                        'slug' => $ancestor->slug,
+                        'excerpt' => $ancestor->excerpt,
+                        'order' => $ancestor->order,
+                        'enabled' => $ancestor->enabled,
+                        'page_type' => $ancestor->page_type,
+                        'created_at' => $ancestor->created_at->format(CarbonImmutable::ISO8601),
+                        'updated_at' => $ancestor->updated_at->format(CarbonImmutable::ISO8601),
+                    ];
+                });
+            }),
+            'landing_page' => $this->whenLoaded('landingPageAncestors', function () {
+                return $this->landingPage ? [
+                    'id' => $this->landingPage->id,
+                    'title' => $this->landingPage->title,
+                    'slug' => $this->landingPage->slug,
+                    'excerpt' => $this->landingPage->excerpt,
+                    'order' => $this->landingPage->order,
+                    'enabled' => $this->landingPage->enabled,
+                    'page_type' => $this->landingPage->page_type,
+                    'created_at' => $this->landingPage->created_at->format(CarbonImmutable::ISO8601),
+                    'updated_at' => $this->landingPage->updated_at->format(CarbonImmutable::ISO8601),
+                ] : null;
+            }),
             'collection_categories' => CollectionCategoryResource::collection($this->whenLoaded('collectionCategories')),
             'collection_personas' => CollectionPersonaResource::collection($this->whenLoaded('collectionPersonas')),
             'created_at' => $this->created_at->format(CarbonImmutable::ISO8601),

--- a/database/factories/PageFactory.php
+++ b/database/factories/PageFactory.php
@@ -20,6 +20,7 @@ class PageFactory extends Factory
         return [
             'title' => $title,
             'slug' => Str::slug($title),
+            'excerpt' => $this->faker->sentence,
             'content' => [
                 'introduction' => [
                     'content' => [

--- a/tests/Feature/PagesTest.php
+++ b/tests/Feature/PagesTest.php
@@ -44,7 +44,7 @@ class PagesTest extends TestCase
                     'id',
                     'slug',
                     'title',
-                    'content',
+                    'excerpt',
                     'order',
                     'enabled',
                     'page_type',
@@ -546,7 +546,7 @@ class PagesTest extends TestCase
                     'id',
                     'slug',
                     'title',
-                    'content',
+                    'excerpt',
                     'order',
                     'enabled',
                     'page_type',
@@ -574,7 +574,7 @@ class PagesTest extends TestCase
                     'id',
                     'slug',
                     'title',
-                    'content',
+                    'excerpt',
                     'order',
                     'enabled',
                     'page_type',
@@ -602,7 +602,7 @@ class PagesTest extends TestCase
                     'id',
                     'slug',
                     'title',
-                    'content',
+                    'excerpt',
                     'order',
                     'enabled',
                     'page_type',
@@ -612,13 +612,9 @@ class PagesTest extends TestCase
                             'id',
                             'slug',
                             'title',
-                            'image',
-                            'content',
                             'order',
                             'enabled',
                             'page_type',
-                            'created_at',
-                            'updated_at',
                         ],
                     ],
                     'created_at',
@@ -648,7 +644,7 @@ class PagesTest extends TestCase
                     'id',
                     'slug',
                     'title',
-                    'content',
+                    'excerpt',
                     'order',
                     'enabled',
                     'page_type',
@@ -961,6 +957,7 @@ class PagesTest extends TestCase
             'landing_page',
             'parent',
             'children',
+            'ancestors',
             'collection_categories',
             'collection_personas',
             'created_at',
@@ -2616,30 +2613,26 @@ class PagesTest extends TestCase
                 'updated_at',
             ],
             'landing_page',
-            'parent' => [
-                'id',
-                'slug',
-                'title',
-                'image',
-                'content',
-                'order',
-                'enabled',
-                'page_type',
-                'created_at',
-                'updated_at',
-            ],
             'children' => [
                 '*' => [
                     'id',
                     'slug',
                     'title',
-                    'image',
-                    'content',
-                    'order',
-                    'enabled',
+                    'excerpt',
                     'page_type',
-                    'created_at',
-                    'updated_at',
+                    'enabled',
+                    'order',
+                ],
+            ],
+            'ancestors' => [
+                '*' => [
+                    'id',
+                    'slug',
+                    'title',
+                    'excerpt',
+                    'page_type',
+                    'enabled',
+                    'order',
                 ],
             ],
             'created_at',
@@ -2678,15 +2671,13 @@ class PagesTest extends TestCase
                     'id',
                     'slug',
                     'title',
-                    'image',
-                    'content',
-                    'order',
-                    'enabled',
+                    'excerpt',
                     'page_type',
-                    'created_at',
-                    'updated_at',
+                    'enabled',
+                    'order',
                 ],
             ],
+            'ancestors',
             'created_at',
             'updated_at',
         ]);
@@ -2709,12 +2700,16 @@ class PagesTest extends TestCase
     /**
      * @test
      */
-    public function getEnabledInformationPageWithLandingPageAncestorAsGuest200(): void
+    public function getEnabledInformationPageWithAncestorsAsGuest200(): void
     {
         $page = Page::factory()->withImage()->withChildren()->create();
-        $parent = Page::factory()->create();
+        $parent = Page::factory()->create([
+            'title' => 'Parent',
+        ]);
         $parent->appendNode($page);
-        $landingPage = Page::factory()->landingPage()->create();
+        $landingPage = Page::factory()->landingPage()->create([
+            'title' => 'Landing Page',
+        ]);
         $landingPage->appendNode($parent);
 
         $response = $this->json('GET', '/core/v1/pages/' . $page->id);
@@ -2734,52 +2729,34 @@ class PagesTest extends TestCase
                 'created_at',
                 'updated_at',
             ],
-            'landing_page' => [
-                'id',
-                'title',
-                'image',
-                'content',
-                'order',
-                'enabled',
-                'page_type',
-                'created_at',
-                'updated_at',
-            ],
-            'parent' => [
-                'id',
-                'title',
-                'image',
-                'content',
-                'order',
-                'enabled',
-                'page_type',
-                'created_at',
-                'updated_at',
-            ],
             'children' => [
                 '*' => [
                     'id',
+                    'slug',
                     'title',
-                    'image',
-                    'content',
-                    'order',
-                    'enabled',
+                    'excerpt',
                     'page_type',
-                    'created_at',
-                    'updated_at',
+                    'enabled',
+                    'order',
+                ],
+            ],
+            'ancestors' => [
+                '*' => [
+                    'id',
+                    'slug',
+                    'title',
+                    'excerpt',
+                    'page_type',
+                    'enabled',
+                    'order',
                 ],
             ],
             'created_at',
             'updated_at',
         ]);
 
-        $response->assertJson([
-            'data' => [
-                'landing_page' => [
-                    'id' => $landingPage->id,
-                ],
-            ],
-        ]);
+        $this->assertEquals($landingPage->id, $response->json('data')['ancestors'][0]['id']);
+        $this->assertEquals($parent->id, $response->json('data')['ancestors'][1]['id']);
     }
 
     /**
@@ -2846,30 +2823,26 @@ class PagesTest extends TestCase
                 'updated_at',
             ],
             'landing_page',
-            'parent' => [
-                'id',
-                'slug',
-                'title',
-                'image',
-                'content',
-                'order',
-                'enabled',
-                'page_type',
-                'created_at',
-                'updated_at',
-            ],
             'children' => [
                 '*' => [
                     'id',
                     'slug',
                     'title',
-                    'image',
-                    'content',
-                    'order',
-                    'enabled',
+                    'excerpt',
                     'page_type',
-                    'created_at',
-                    'updated_at',
+                    'enabled',
+                    'order',
+                ],
+            ],
+            'ancestors' => [
+                '*' => [
+                    'id',
+                    'slug',
+                    'title',
+                    'excerpt',
+                    'page_type',
+                    'enabled',
+                    'order',
                 ],
             ],
             'created_at',


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/4090/add-in-breadcrumbs-data-to-api-endpoint-for-pages-slug

- Refactored `PageResource`
- Reduced size of relationship entities `parent`, `landing_page` and `children`
- Added new relationship `ancestors` with a list of ancestors in descending order from root down suitable for breadcrumbs
- Added new `include=ancestors` option for the pages index api to include the ancestors relationship on all page result items

### Development checklist

- [x] Changes have been made to the API?
  - [x] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
