### PR TITLE
Feature/sc 4200/add in alt text fields

### DIFF
--- a/app/Docs/OpenApi.php
+++ b/app/Docs/OpenApi.php
@@ -39,6 +39,7 @@ class OpenApi extends BaseOpenApi implements Responsable
                 Paths\Collections\OrganisationEvents\CollectionOrganisationEventsNestedPath::create(),
                 Paths\Collections\OrganisationEvents\CollectionOrganisationEventsImagePath::create(),
                 Paths\Files\FilesRootPath::create(),
+                Paths\Files\FilesNestedPath::create(),
                 Paths\Locations\LocationsRootPath::create(),
                 Paths\Locations\LocationsIndexPath::create(),
                 Paths\Locations\LocationsNestedPath::create(),

--- a/app/Docs/Operations/Files/ShowFileOperation.php
+++ b/app/Docs/Operations/Files/ShowFileOperation.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Docs\Operations\Files;
+
+use App\Docs\Schemas\File\FileSchema;
+use App\Docs\Schemas\ResourceSchema;
+use App\Docs\Tags\FilesTag;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\BaseObject;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\MediaType;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Operation;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Response;
+
+class ShowFileOperation extends Operation
+{
+    /**
+     * @throws \GoldSpecDigital\ObjectOrientedOAS\Exceptions\InvalidArgumentException
+     */
+    public static function create(string $objectId = null): BaseObject
+    {
+        return parent::create($objectId)
+            ->action(static::ACTION_GET)
+            ->tags(FilesTag::create())
+            ->summary('Get a specific file')
+            ->description('**Permission:** `Open`')
+            ->noSecurity()
+            ->responses(
+                Response::ok()->content(
+                    MediaType::json()->schema(
+                        ResourceSchema::create(null, FileSchema::create())
+                    )
+                )
+            );
+    }
+}

--- a/app/Docs/Paths/Files/FilesNestedPath.php
+++ b/app/Docs/Paths/Files/FilesNestedPath.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Docs\Paths\Files;
+
+use App\Docs\Operations\Files\ShowFileOperation;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\BaseObject;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Parameter;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\PathItem;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Schema;
+
+class FilesNestedPath extends PathItem
+{
+    /**
+     * @throws \GoldSpecDigital\ObjectOrientedOAS\Exceptions\InvalidArgumentException
+     */
+    public static function create(string $objectId = null): BaseObject
+    {
+        return parent::create($objectId)
+            ->route('/files/{file}')
+            ->parameters(
+                Parameter::path()
+                    ->name('file')
+                    ->description('The ID of the file')
+                    ->required()
+                    ->schema(Schema::string()->format(Schema::FORMAT_UUID))
+            )
+            ->operations(
+                ShowFileOperation::create(),
+            );
+    }
+}

--- a/app/Docs/Schemas/Collection/Category/CollectionCategorySchema.php
+++ b/app/Docs/Schemas/Collection/Category/CollectionCategorySchema.php
@@ -29,6 +29,13 @@ class CollectionCategorySchema extends Schema
                             Schema::string('content')
                         )
                     ),
+                Schema::object('image')
+                    ->properties(
+                        Schema::string('id'),
+                        Schema::string('mime_type'),
+                        Schema::string('alt_text')
+                    )
+                    ->nullable(),
                 Schema::array('category_taxonomies')
                     ->items(TaxonomyCategorySchema::create()),
                 Schema::string('created_at')

--- a/app/Docs/Schemas/Collection/OrganisationEvent/CollectionOrganisationEventSchema.php
+++ b/app/Docs/Schemas/Collection/OrganisationEvent/CollectionOrganisationEventSchema.php
@@ -28,6 +28,13 @@ class CollectionOrganisationEventSchema extends Schema
                             Schema::string('content')
                         )
                     ),
+                Schema::object('image')
+                    ->properties(
+                        Schema::string('id'),
+                        Schema::string('mime_type'),
+                        Schema::string('alt_text')
+                    )
+                    ->nullable(),
                 Schema::array('category_taxonomies')
                     ->items(TaxonomyCategorySchema::create()),
                 Schema::string('created_at')

--- a/app/Docs/Schemas/Collection/Persona/CollectionPersonaSchema.php
+++ b/app/Docs/Schemas/Collection/Persona/CollectionPersonaSchema.php
@@ -30,6 +30,13 @@ class CollectionPersonaSchema extends Schema
                             Schema::string('content')
                         )
                     ),
+                Schema::object('image')
+                    ->properties(
+                        Schema::string('id'),
+                        Schema::string('mime_type'),
+                        Schema::string('alt_text')
+                    )
+                    ->nullable(),
                 Schema::array('category_taxonomies')
                     ->items(TaxonomyCategorySchema::create()),
                 Schema::string('created_at')

--- a/app/Docs/Schemas/File/FileSchema.php
+++ b/app/Docs/Schemas/File/FileSchema.php
@@ -23,6 +23,14 @@ class FileSchema extends Schema
                         File::MIME_TYPE_JPEG,
                         File::MIME_TYPE_SVG
                     ),
+                Schema::string('alt_text')
+                    ->nullable(),
+                Schema::string('max_dimension')
+                    ->format(Schema::FORMAT_INT32)
+                    ->nullable(),
+                Schema::string('src')
+                    ->format(static::FORMAT_BINARY)
+                    ->description('Base64 encoded string of the image'),
                 Schema::string('created_at')
                     ->format(Schema::FORMAT_DATE_TIME)
                     ->nullable(),

--- a/app/Docs/Schemas/File/StoreFileSchema.php
+++ b/app/Docs/Schemas/File/StoreFileSchema.php
@@ -18,6 +18,7 @@ class StoreFileSchema extends Schema
             ->required(
                 'is_private',
                 'mime_type',
+                'alt_text',
                 'file'
             )
             ->properties(
@@ -29,6 +30,7 @@ class StoreFileSchema extends Schema
                         File::MIME_TYPE_JPEG,
                         File::MIME_TYPE_SVG
                     ),
+                Schema::string('alt_text'),
                 Schema::string('file')
                     ->format(static::FORMAT_BINARY)
                     ->description('Base64 encoded string of the image')

--- a/app/Docs/Schemas/Location/LocationSchema.php
+++ b/app/Docs/Schemas/Location/LocationSchema.php
@@ -28,6 +28,13 @@ class LocationSchema extends Schema
                     ->format(Schema::FORMAT_FLOAT),
                 Schema::number('lon')
                     ->format(Schema::FORMAT_FLOAT),
+                Schema::object('image')
+                    ->properties(
+                        Schema::string('id'),
+                        Schema::string('mime_type'),
+                        Schema::string('alt_text')
+                    )
+                    ->nullable(),
                 Schema::string('accessibility_info')
                     ->nullable(),
                 Schema::boolean('has_wheelchair_access'),

--- a/app/Docs/Schemas/Organisation/OrganisationSchema.php
+++ b/app/Docs/Schemas/Organisation/OrganisationSchema.php
@@ -20,6 +20,13 @@ class OrganisationSchema extends Schema
                 Schema::string('name'),
                 Schema::string('slug'),
                 Schema::string('description'),
+                Schema::object('image')
+                    ->properties(
+                        Schema::string('id'),
+                        Schema::string('mime_type'),
+                        Schema::string('alt_text')
+                    )
+                    ->nullable(),
                 Schema::string('url')
                     ->nullable(),
                 Schema::string('email')

--- a/app/Docs/Schemas/OrganisationEvent/OrganisationEventSchema.php
+++ b/app/Docs/Schemas/OrganisationEvent/OrganisationEventSchema.php
@@ -21,6 +21,13 @@ class OrganisationEventSchema extends Schema
                 Schema::string('title'),
                 Schema::string('intro'),
                 Schema::string('description'),
+                Schema::object('image')
+                    ->properties(
+                        Schema::string('id'),
+                        Schema::string('mime_type'),
+                        Schema::string('alt_text')
+                    )
+                    ->nullable(),
                 Schema::string('start_date')
                     ->format(Schema::FORMAT_DATE),
                 Schema::string('end_date')

--- a/app/Docs/Schemas/Page/PageSchema.php
+++ b/app/Docs/Schemas/Page/PageSchema.php
@@ -4,7 +4,6 @@ namespace App\Docs\Schemas\Page;
 
 use App\Docs\Schemas\Collection\Category\CollectionCategorySchema;
 use App\Docs\Schemas\Collection\Persona\CollectionPersonaSchema;
-use App\Docs\Schemas\File\FileSchema;
 use App\Models\Page;
 use GoldSpecDigital\ObjectOrientedOAS\Objects\BaseObject;
 use GoldSpecDigital\ObjectOrientedOAS\Objects\Schema;
@@ -29,7 +28,13 @@ class PageSchema extends Schema
                         Page::PAGE_TYPE_INFORMATION,
                         Page::PAGE_TYPE_LANDING
                     ),
-                FileSchema::create('image'),
+                Schema::object('image')
+                    ->properties(
+                        Schema::string('id'),
+                        Schema::string('mime_type'),
+                        Schema::string('alt_text')
+                    )
+                    ->nullable(),
                 PageListItemSchema::create('landing_page'),
                 PageListItemSchema::create('parent'),
                 Schema::array('children')

--- a/app/Docs/Schemas/Service/GalleryItemSchema.php
+++ b/app/Docs/Schemas/Service/GalleryItemSchema.php
@@ -15,6 +15,8 @@ class GalleryItemSchema extends Schema
                 Schema::string('file_id')
                     ->format(Schema::FORMAT_UUID),
                 Schema::string('url'),
+                Schema::string('mime_type'),
+                Schema::string('alt_text'),
                 Schema::string('created_at')
                     ->format(Schema::FORMAT_DATE_TIME)
                     ->nullable(),

--- a/app/Docs/Schemas/Service/ServiceSchema.php
+++ b/app/Docs/Schemas/Service/ServiceSchema.php
@@ -33,6 +33,13 @@ class ServiceSchema extends Schema
                     ->enum(Service::STATUS_ACTIVE, Service::STATUS_INACTIVE),
                 Schema::string('intro'),
                 Schema::string('description'),
+                Schema::object('image')
+                    ->properties(
+                        Schema::string('id'),
+                        Schema::string('mime_type'),
+                        Schema::string('alt_text')
+                    )
+                    ->nullable(),
                 Schema::string('wait_time')
                     ->enum(
                         Service::WAIT_TIME_ONE_WEEK,

--- a/app/Http/Controllers/Core/V1/CollectionCategoryController.php
+++ b/app/Http/Controllers/Core/V1/CollectionCategoryController.php
@@ -141,14 +141,14 @@ class CollectionCategoryController extends Controller
             // Update the collection record.
             $collection->update([
                 'slug' => $slugGenerator->compareEquals($request->name, $collection->slug)
-                    ? $collection->slug
-                    : $slugGenerator->generate($request->name, table(Collection::class)),
+                ? $collection->slug
+                : $slugGenerator->generate($request->name, table(Collection::class)),
                 'name' => $request->name,
                 'meta' => [
                     'intro' => $request->intro,
                     'image_file_id' => $request->has('image_file_id')
-                        ? $request->image_file_id
-                        : $collection->meta['image_file_id'] ?? null,
+                    ? $request->image_file_id
+                    : $collection->meta['image_file_id'] ?? null,
                     'sideboxes' => $sideboxes,
                 ],
                 'order' => $request->order,

--- a/app/Http/Controllers/Core/V1/FileController.php
+++ b/app/Http/Controllers/Core/V1/FileController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Core\V1;
 
 use App\Events\EndpointHit;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\File\ShowRequest;
 use App\Http\Requests\File\StoreRequest;
 use App\Http\Resources\FileResource;
 use App\Models\File;
@@ -16,7 +17,7 @@ class FileController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('auth:api');
+        $this->middleware('auth:api')->except('show');
     }
 
     /**
@@ -33,6 +34,7 @@ class FileController extends Controller
                 'mime_type' => $request->mime_type,
                 'meta' => [
                     'type' => File::META_TYPE_PENDING_ASSIGNMENT,
+                    'alt_text' => $request->alt_text,
                 ],
                 'is_private' => $request->is_private,
             ]);
@@ -43,5 +45,15 @@ class FileController extends Controller
 
             return new FileResource($file);
         });
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function show(ShowRequest $request, File $file)
+    {
+        return new FileResource($file);
     }
 }

--- a/app/Http/Requests/CollectionPersona/StoreRequest.php
+++ b/app/Http/Requests/CollectionPersona/StoreRequest.php
@@ -44,7 +44,7 @@ class StoreRequest extends FormRequest
             'category_taxonomies.*' => ['string', 'exists:taxonomies,id', new RootTaxonomyIs(Taxonomy::NAME_CATEGORY)],
             'image_file_id' => [
                 'exists:files,id',
-                new FileIsMimeType(File::MIME_TYPE_PNG),
+                new FileIsMimeType(File::MIME_TYPE_PNG, File::MIME_TYPE_JPG, File::MIME_TYPE_JPEG, File::MIME_TYPE_SVG),
                 new FileIsPendingAssignment(),
             ],
         ];

--- a/app/Http/Requests/CollectionPersona/UpdateRequest.php
+++ b/app/Http/Requests/CollectionPersona/UpdateRequest.php
@@ -70,7 +70,7 @@ class UpdateRequest extends FormRequest
             'image_file_id' => [
                 'nullable',
                 'exists:files,id',
-                new FileIsMimeType(File::MIME_TYPE_PNG),
+                new FileIsMimeType(File::MIME_TYPE_PNG, File::MIME_TYPE_JPG, File::MIME_TYPE_JPEG, File::MIME_TYPE_SVG),
                 new FileIsPendingAssignment(),
             ],
         ];

--- a/app/Http/Requests/File/ShowRequest.php
+++ b/app/Http/Requests/File/ShowRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests\File;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ShowRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     */
+    public function rules(): array
+    {
+        return [
+            'max_dimensions' => 'sometimes|numeric|between:1,1000',
+        ];
+    }
+}

--- a/app/Http/Requests/File/StoreRequest.php
+++ b/app/Http/Requests/File/StoreRequest.php
@@ -29,6 +29,7 @@ class StoreRequest extends FormRequest
             'is_private' => ['required', 'boolean'],
             'mime_type' => ['required', Rule::in([File::MIME_TYPE_PNG, File::MIME_TYPE_JPG, File::MIME_TYPE_JPEG, File::MIME_TYPE_SVG])],
             'file' => ['required', 'string'],
+            'alt_text' => ['required', 'string', 'min:1'],
         ];
     }
 }

--- a/app/Http/Requests/OrganisationEvent/StoreRequest.php
+++ b/app/Http/Requests/OrganisationEvent/StoreRequest.php
@@ -162,7 +162,7 @@ class StoreRequest extends FormRequest
             'image_file_id' => [
                 'nullable',
                 'exists:files,id',
-                new FileIsMimeType(File::MIME_TYPE_PNG, File::MIME_TYPE_JPG, File::MIME_TYPE_SVG),
+                new FileIsMimeType(File::MIME_TYPE_PNG, File::MIME_TYPE_JPG, File::MIME_TYPE_JPEG, File::MIME_TYPE_SVG),
                 new FileIsPendingAssignment(),
             ],
             'category_taxonomies' => [

--- a/app/Http/Requests/OrganisationEvent/UpdateRequest.php
+++ b/app/Http/Requests/OrganisationEvent/UpdateRequest.php
@@ -165,7 +165,7 @@ class UpdateRequest extends FormRequest
             'image_file_id' => [
                 'nullable',
                 'exists:files,id',
-                new FileIsMimeType(File::MIME_TYPE_PNG),
+                new FileIsMimeType(File::MIME_TYPE_PNG, File::MIME_TYPE_JPG, File::MIME_TYPE_JPEG, File::MIME_TYPE_SVG),
                 new FileIsPendingAssignment(),
             ],
             'category_taxonomies' => [

--- a/app/Http/Resources/CollectionCategoryResource.php
+++ b/app/Http/Resources/CollectionCategoryResource.php
@@ -19,6 +19,13 @@ class CollectionCategoryResource extends JsonResource
             'name' => $this->name,
             'intro' => $this->meta['intro'],
             'image_file_id' => $this->meta['image_file_id'] ?? null,
+            'image' => $this->image ? [
+                'id' => $this->image->id,
+                'mime_type' => $this->image->mime_type,
+                'alt_text' => $this->image->meta['alt_text'] ?? null,
+                'created_at' => $this->image->created_at->format(CarbonImmutable::ISO8601),
+                'updated_at' => $this->image->updated_at->format(CarbonImmutable::ISO8601),
+            ] : null,
             'order' => $this->order,
             'enabled' => $this->enabled,
             'homepage' => $this->homepage,

--- a/app/Http/Resources/CollectionCategoryResource.php
+++ b/app/Http/Resources/CollectionCategoryResource.php
@@ -23,8 +23,6 @@ class CollectionCategoryResource extends JsonResource
                 'id' => $this->image->id,
                 'mime_type' => $this->image->mime_type,
                 'alt_text' => $this->image->meta['alt_text'] ?? null,
-                'created_at' => $this->image->created_at->format(CarbonImmutable::ISO8601),
-                'updated_at' => $this->image->updated_at->format(CarbonImmutable::ISO8601),
             ] : null,
             'order' => $this->order,
             'enabled' => $this->enabled,

--- a/app/Http/Resources/CollectionOrganisationEventResource.php
+++ b/app/Http/Resources/CollectionOrganisationEventResource.php
@@ -19,6 +19,11 @@ class CollectionOrganisationEventResource extends JsonResource
             'name' => $this->name,
             'intro' => $this->meta['intro'],
             'image_file_id' => $this->meta['image_file_id'] ?? null,
+            'image' => $this->image ? [
+                'id' => $this->image->id,
+                'mime_type' => $this->image->mime_type,
+                'alt_text' => $this->image->meta['alt_text'] ?? null,
+            ] : null,
             'order' => $this->order,
             'enabled' => $this->enabled,
             'sideboxes' => $this->meta['sideboxes'],

--- a/app/Http/Resources/CollectionPersonaResource.php
+++ b/app/Http/Resources/CollectionPersonaResource.php
@@ -23,6 +23,11 @@ class CollectionPersonaResource extends JsonResource
             'enabled' => $this->enabled,
             'homepage' => $this->homepage,
             'sideboxes' => $this->meta['sideboxes'],
+            'image' => $this->image ? [
+                'id' => $this->image->id,
+                'mime_type' => $this->image->mime_type,
+                'alt_text' => $this->image->meta['alt_text'] ?? null,
+            ] : null,
             'category_taxonomies' => TaxonomyResource::collection($this->taxonomies),
             'created_at' => $this->created_at->format(CarbonImmutable::ISO8601),
             'updated_at' => $this->updated_at->format(CarbonImmutable::ISO8601),

--- a/app/Http/Resources/FileResource.php
+++ b/app/Http/Resources/FileResource.php
@@ -17,6 +17,9 @@ class FileResource extends JsonResource
             'id' => $this->id,
             'mime_type' => $this->mime_type,
             'is_private' => $this->is_private,
+            'alt_text' => $this->meta['alt_text'] ?? null,
+            'max_dimension' => $this->meta['max_dimension'] ?? null,
+            'src' => 'data:' . $this->mime_type . ';base64,' . base64_encode($this->getContent()),
             'created_at' => $this->created_at->format(CarbonImmutable::ISO8601),
             'updated_at' => $this->updated_at->format(CarbonImmutable::ISO8601),
         ];

--- a/app/Http/Resources/LocationResource.php
+++ b/app/Http/Resources/LocationResource.php
@@ -25,6 +25,11 @@ class LocationResource extends JsonResource
             'country' => $this->country,
             'lat' => $this->lat,
             'lon' => $this->lon,
+            'image' => $this->imageFile ? [
+                'id' => $this->imageFile->id,
+                'mime_type' => $this->imageFile->mime_type,
+                'alt_text' => $this->imageFile->altText,
+            ] : null,
             'accessibility_info' => $this->accessibility_info,
             'has_wheelchair_access' => $this->has_wheelchair_access,
             'has_induction_loop' => $this->has_induction_loop,

--- a/app/Http/Resources/OrganisationEventResource.php
+++ b/app/Http/Resources/OrganisationEventResource.php
@@ -20,6 +20,11 @@ class OrganisationEventResource extends JsonResource
             'title' => $this->title,
             'intro' => $this->intro,
             'description' => $this->description,
+            'image' => $this->imageFile ? [
+                'id' => $this->imageFile->id,
+                'mime_type' => $this->imageFile->mime_type,
+                'alt_text' => $this->imageFile->altText,
+            ] : null,
             'start_date' => $this->start_date->toDateString(),
             'end_date' => $this->end_date->toDateString(),
             'start_time' => $this->start_time,

--- a/app/Http/Resources/OrganisationResource.php
+++ b/app/Http/Resources/OrganisationResource.php
@@ -19,6 +19,11 @@ class OrganisationResource extends JsonResource
             'slug' => $this->slug,
             'name' => $this->name,
             'description' => $this->description,
+            'image' => $this->logoFile ? [
+                'id' => $this->logoFile->id,
+                'mime_type' => $this->logoFile->mime_type,
+                'alt_text' => $this->logoFile->altText,
+            ] : null,
             'url' => $this->url,
             'email' => $this->email,
             'phone' => $this->phone,

--- a/app/Http/Resources/PageResource.php
+++ b/app/Http/Resources/PageResource.php
@@ -22,7 +22,11 @@ class PageResource extends JsonResource
             'order' => $this->order,
             'enabled' => $this->enabled,
             'page_type' => $this->page_type,
-            'image' => new FileResource($this->image),
+            'image' => $this->image ? [
+                'id' => $this->image->id,
+                'mime_type' => $this->image->mime_type,
+                'alt_text' => $this->image->altText,
+            ] : null,
             'parent' => $this->whenLoaded('parent', function () {
                 return $this->parent ? [
                     'id' => $this->parent->id,

--- a/app/Http/Resources/ServiceGalleryItemResource.php
+++ b/app/Http/Resources/ServiceGalleryItemResource.php
@@ -16,6 +16,8 @@ class ServiceGalleryItemResource extends JsonResource
         return [
             'file_id' => $this->file_id,
             'url' => $this->url(),
+            'mime_type' => $this->file->mime_type,
+            'alt_text' => $this->file->meta['alt_text'] ?? null,
             'created_at' => $this->created_at->format(CarbonImmutable::ISO8601),
             'updated_at' => $this->updated_at->format(CarbonImmutable::ISO8601),
         ];

--- a/app/Http/Resources/ServiceResource.php
+++ b/app/Http/Resources/ServiceResource.php
@@ -23,6 +23,11 @@ class ServiceResource extends JsonResource
             'status' => $this->status,
             'intro' => $this->intro,
             'description' => $this->description,
+            'image' => $this->logoFile ? [
+                'id' => $this->logoFile->id,
+                'mime_type' => $this->logoFile->mime_type,
+                'alt_text' => $this->logoFile->altText,
+            ] : null,
             'wait_time' => $this->wait_time,
             'is_free' => $this->is_free,
             'fees_text' => $this->fees_text,

--- a/app/Models/Collection.php
+++ b/app/Models/Collection.php
@@ -31,6 +31,7 @@ class Collection extends Model
     protected $casts = [
         'enabled' => 'boolean',
         'homepage' => 'boolean',
+        'meta' => 'array',
     ];
 
     /**

--- a/app/Models/File.php
+++ b/app/Models/File.php
@@ -61,6 +61,7 @@ class File extends Model implements Responsable
         'is_private' => 'boolean',
         'created_at' => 'datetime',
         'updated_at' => 'datetime',
+        'meta' => 'array',
     ];
 
     /**

--- a/app/Models/File.php
+++ b/app/Models/File.php
@@ -8,6 +8,7 @@ use App\Models\Relationships\FileRelationships;
 use App\Models\Scopes\FileScopes;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\MassAssignmentException;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Storage;
 
@@ -31,6 +32,8 @@ class File extends Model implements Responsable
     const META_TYPE_RESIZED_IMAGE = 'resized_image';
 
     const META_TYPE_PENDING_ASSIGNMENT = 'pending_assignment';
+
+    const META_TYPE_ASSIGNED = 'assigned';
 
     const META_PLACEHOLDER_FOR_ORGANISATION = 'organisation';
 
@@ -253,9 +256,17 @@ class File extends Model implements Responsable
         return $withPeriod ? $map[$mimeType] : trim($map[$mimeType], '.');
     }
 
+    /**
+     * Set the pending_assignment / assigned meta value.
+     *
+     * @throws MassAssignmentException
+     * @return File
+     */
     public function assigned(): self
     {
-        $this->update(['meta' => null]);
+        $meta = $this->meta;
+        $meta['type'] = self::META_TYPE_ASSIGNED;
+        $this->update(['meta' => $meta]);
 
         return $this;
     }

--- a/app/Models/Mutators/CollectionMutators.php
+++ b/app/Models/Mutators/CollectionMutators.php
@@ -2,15 +2,24 @@
 
 namespace App\Models\Mutators;
 
+use App\Models\File;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+
 trait CollectionMutators
 {
-    public function getMetaAttribute(string $meta): array
+    /**
+     * Get the related image File.
+     *
+     * @return App\Models\File
+     */
+    protected function image(): Attribute
     {
-        return json_decode($meta, true);
-    }
+        return Attribute::make(
+            get: function (mixed $value, array $attributes) {
+                $meta = json_decode($attributes['meta']);
 
-    public function setMetaAttribute(array $meta)
-    {
-        $this->attributes['meta'] = json_encode($meta);
+                return isset($meta->image_file_id) ? File::find($meta->image_file_id) : null;
+            }
+        );
     }
 }

--- a/app/Models/Mutators/FileMutators.php
+++ b/app/Models/Mutators/FileMutators.php
@@ -32,4 +32,20 @@ trait FileMutators
             }
         );
     }
+
+    /**
+     * Get the alt_text meta value.
+     *
+     * @return string
+     */
+    protected function altText(): Attribute
+    {
+        return Attribute::make(
+            get: function (mixed $value, array $attributes) {
+                $meta = json_decode($attributes['meta']);
+
+                return $meta->alt_text ?? null;
+            }
+        );
+    }
 }

--- a/app/Models/Mutators/FileMutators.php
+++ b/app/Models/Mutators/FileMutators.php
@@ -4,13 +4,13 @@ namespace App\Models\Mutators;
 
 trait FileMutators
 {
-    public function getMetaAttribute(?string $meta): ?array
-    {
-        return ($meta === null) ? null : json_decode($meta, true);
-    }
+    // public function getMetaAttribute(?string $meta): ?array
+    // {
+    //     return ($meta === null) ? null : json_decode($meta, true);
+    // }
 
-    public function setMetaAttribute(?array $meta)
-    {
-        $this->attributes['meta'] = ($meta === null) ? null : json_encode($meta);
-    }
+    // public function setMetaAttribute(?array $meta)
+    // {
+    //     $this->attributes['meta'] = ($meta === null) ? null : json_encode($meta);
+    // }
 }

--- a/app/Models/Mutators/FileMutators.php
+++ b/app/Models/Mutators/FileMutators.php
@@ -2,6 +2,9 @@
 
 namespace App\Models\Mutators;
 
+use App\Models\File;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+
 trait FileMutators
 {
     // public function getMetaAttribute(?string $meta): ?array
@@ -13,4 +16,20 @@ trait FileMutators
     // {
     //     $this->attributes['meta'] = ($meta === null) ? null : json_encode($meta);
     // }
+
+    /**
+     * Get the pending_assignment meta value.
+     *
+     * @return bool
+     */
+    protected function pendingAssignment(): Attribute
+    {
+        return Attribute::make(
+            get: function (mixed $value, array $attributes) {
+                $meta = json_decode($attributes['meta']);
+
+                return $meta->type ? $meta->type === File::META_TYPE_PENDING_ASSIGNMENT : false;
+            }
+        );
+    }
 }

--- a/app/Models/Relationships/OrganisationEventRelationships.php
+++ b/app/Models/Relationships/OrganisationEventRelationships.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\Relationships;
 
+use App\Models\File;
 use App\Models\Location;
 use App\Models\Organisation;
 use App\Models\OrganisationEventTaxonomy;
@@ -38,5 +39,15 @@ trait OrganisationEventRelationships
     public function taxonomyRelationship(): HasMany
     {
         return $this->organisationEventTaxonomies();
+    }
+
+    /**
+     * Return the image relationship.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function imageFile(): BelongsTo
+    {
+        return $this->belongsTo(File::class, 'image_file_id');
     }
 }

--- a/database/factories/FileFactory.php
+++ b/database/factories/FileFactory.php
@@ -31,7 +31,11 @@ class FileFactory extends Factory
         return $this->afterCreating(function (File $file) {
             $image = Storage::disk('local')->get('/test-data/image.png');
             $file->uploadBase64EncodedFile('data:image/png;base64,' . base64_encode($image));
-        })->state(['filename' => Str::random() . '.png', 'mime_type' => 'image/png']);
+        })->state([
+            'filename' => Str::random() . '.png',
+            'mime_type' => 'image/png',
+            'meta' => ['alt_text' => $this->faker->sentence],
+        ]);
     }
 
     public function imageJpg()
@@ -39,7 +43,11 @@ class FileFactory extends Factory
         return $this->afterCreating(function (File $file) {
             $image = Storage::disk('local')->get('/test-data/image.jpg');
             $file->uploadBase64EncodedFile('data:image/jpeg;base64,' . base64_encode($image));
-        })->state(['filename' => Str::random() . '.jpg', 'mime_type' => 'image/jpeg']);
+        })->state([
+            'filename' => Str::random() . '.jpg',
+            'mime_type' => 'image/jpeg',
+            'meta' => ['alt_text' => $this->faker->sentence],
+        ]);
     }
 
     public function imageSvg()
@@ -47,6 +55,10 @@ class FileFactory extends Factory
         return $this->afterCreating(function (File $file) {
             $image = Storage::disk('local')->get('/test-data/image.svg');
             $file->uploadBase64EncodedFile('data:image/svg+xml;base64,' . base64_encode($image));
-        })->state(['filename' => Str::random() . '.svg', 'mime_type' => 'image/svg+xml']);
+        })->state([
+            'filename' => Str::random() . '.svg',
+            'mime_type' => 'image/svg+xml',
+            'meta' => ['alt_text' => $this->faker->sentence],
+        ]);
     }
 }

--- a/database/factories/FileFactory.php
+++ b/database/factories/FileFactory.php
@@ -18,12 +18,16 @@ class FileFactory extends Factory
             'filename' => Str::random() . '.dat',
             'mime_type' => 'text/plain',
             'is_private' => false,
+            'meta' => ['alt_text' => $this->faker->sentence],
         ];
     }
 
     public function pendingAssignment()
     {
-        return $this->state(['meta' => ['type' => File::META_TYPE_PENDING_ASSIGNMENT]]);
+        return $this->state(['meta' => [
+            'type' => File::META_TYPE_PENDING_ASSIGNMENT,
+            'alt_text' => $this->faker->sentence,
+        ]]);
     }
 
     public function imagePng()
@@ -34,7 +38,6 @@ class FileFactory extends Factory
         })->state([
             'filename' => Str::random() . '.png',
             'mime_type' => 'image/png',
-            'meta' => ['alt_text' => $this->faker->sentence],
         ]);
     }
 
@@ -46,7 +49,6 @@ class FileFactory extends Factory
         })->state([
             'filename' => Str::random() . '.jpg',
             'mime_type' => 'image/jpeg',
-            'meta' => ['alt_text' => $this->faker->sentence],
         ]);
     }
 
@@ -58,7 +60,6 @@ class FileFactory extends Factory
         })->state([
             'filename' => Str::random() . '.svg',
             'mime_type' => 'image/svg+xml',
-            'meta' => ['alt_text' => $this->faker->sentence],
         ]);
     }
 }

--- a/database/factories/ServiceFactory.php
+++ b/database/factories/ServiceFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Models\File;
 use App\Models\Service;
 use App\Models\SocialMedia;
 use App\Models\Taxonomy;
@@ -47,6 +48,24 @@ class ServiceFactory extends Factory
         return $this->state(function () {
             return [
                 'score' => $this->faker->numberBetween(1, 5),
+            ];
+        });
+    }
+
+    public function withJpgLogo()
+    {
+        return $this->state(function () {
+            return [
+                'logo_file_id' => File::factory()->imageJpg()->create(),
+            ];
+        });
+    }
+
+    public function withPngLogo()
+    {
+        return $this->state(function () {
+            return [
+                'logo_file_id' => File::factory()->imagePng()->create(),
             ];
         });
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -82,7 +82,7 @@ Route::prefix('/core/v1')
 
             // Files.
             Route::apiResource('/files', Core\V1\FileController::class)
-                ->only('store');
+                ->only('store', 'show');
 
             // Locations.
             Route::match(['GET', 'POST'], '/locations/index', [Core\V1\LocationController::class, 'index']);

--- a/tests/Feature/CollectionCategoriesTest.php
+++ b/tests/Feature/CollectionCategoriesTest.php
@@ -42,6 +42,7 @@ class CollectionCategoriesTest extends TestCase
             'enabled',
             'homepage',
             'image_file_id',
+            'image',
             'sideboxes' => [
                 '*' => [
                     'title',
@@ -86,6 +87,7 @@ class CollectionCategoriesTest extends TestCase
                     'enabled',
                     'homepage',
                     'image_file_id',
+                    'image',
                     'sideboxes' => [
                         '*' => [
                             'title',
@@ -281,10 +283,7 @@ class CollectionCategoriesTest extends TestCase
         $user->makeSuperAdmin();
         $randomCategory = Taxonomy::category()->children()->inRandomOrder()->firstOrFail();
 
-        $image = File::factory()->pendingAssignment()->create([
-            'filename' => Str::random() . '.svg',
-            'mime_type' => 'image/svg+xml',
-        ]);
+        $image = File::factory()->pendingAssignment()->imageSvg()->create();
 
         $base64Image = 'data:image/svg+xml;base64,' . base64_encode(Storage::disk('local')->get('/test-data/image.svg'));
 
@@ -318,6 +317,7 @@ class CollectionCategoriesTest extends TestCase
             'enabled',
             'homepage',
             'image_file_id',
+            'image',
             'sideboxes' => [
                 '*' => [
                     'title',
@@ -622,10 +622,17 @@ class CollectionCategoriesTest extends TestCase
 
         $this->assertEquals($image->id, $collectionArray['image_file_id']);
 
-        $this->assertDatabaseHas($image->getTable(), [
-            'id' => $image->id,
-            'meta' => null,
+        $response->assertJsonFragment([
+            'image' => [
+                'id' => $image->id,
+                'mime_type' => $image->mime_type,
+                'alt_text' => $image->meta['alt_text'],
+                'created_at' => $image->created_at->format(CarbonImmutable::ISO8601),
+                'updated_at' => $image->updated_at->format(CarbonImmutable::ISO8601),
+            ],
         ]);
+
+        $this->assertFalse($image->fresh()->pendingAssignment);
 
         // PNG
         $image = File::factory()->pendingAssignment()->imagePng()->create();
@@ -654,10 +661,17 @@ class CollectionCategoriesTest extends TestCase
 
         $this->assertEquals($image->id, $collectionArray['image_file_id']);
 
-        $this->assertDatabaseHas($image->getTable(), [
-            'id' => $image->id,
-            'meta' => null,
+        $response->assertJsonFragment([
+            'image' => [
+                'id' => $image->id,
+                'mime_type' => $image->mime_type,
+                'alt_text' => $image->meta['alt_text'],
+                'created_at' => $image->created_at->format(CarbonImmutable::ISO8601),
+                'updated_at' => $image->updated_at->format(CarbonImmutable::ISO8601),
+            ],
         ]);
+
+        $this->assertFalse($image->fresh()->pendingAssignment);
 
         // JPG
         $image = File::factory()->pendingAssignment()->imageJpg()->create();
@@ -686,10 +700,17 @@ class CollectionCategoriesTest extends TestCase
 
         $this->assertEquals($image->id, $collectionArray['image_file_id']);
 
-        $this->assertDatabaseHas($image->getTable(), [
-            'id' => $image->id,
-            'meta' => null,
+        $response->assertJsonFragment([
+            'image' => [
+                'id' => $image->id,
+                'mime_type' => $image->mime_type,
+                'alt_text' => $image->meta['alt_text'],
+                'created_at' => $image->created_at->format(CarbonImmutable::ISO8601),
+                'updated_at' => $image->updated_at->format(CarbonImmutable::ISO8601),
+            ],
         ]);
+
+        $this->assertFalse($image->fresh()->pendingAssignment);
     }
 
     /**
@@ -1096,6 +1117,7 @@ class CollectionCategoriesTest extends TestCase
             'order',
             'enabled',
             'image_file_id',
+            'image',
             'homepage',
             'sideboxes' => [
                 '*' => [
@@ -1146,6 +1168,7 @@ class CollectionCategoriesTest extends TestCase
             'order',
             'enabled',
             'image_file_id',
+            'image',
             'homepage',
             'sideboxes' => [
                 '*' => [
@@ -1442,10 +1465,7 @@ class CollectionCategoriesTest extends TestCase
         $category = Collection::categories()->inRandomOrder()->firstOrFail();
         $taxonomy = Taxonomy::category()->children()->inRandomOrder()->firstOrFail();
 
-        $image = File::factory()->pendingAssignment()->create([
-            'filename' => Str::random() . '.svg',
-            'mime_type' => 'image/svg+xml',
-        ]);
+        $image = File::factory()->pendingAssignment()->imageSvg()->create();
 
         $base64Image = 'data:image/svg+xml;base64,' . base64_encode(Storage::disk('local')->get('/test-data/image.svg'));
 
@@ -1474,6 +1494,7 @@ class CollectionCategoriesTest extends TestCase
             'enabled',
             'homepage',
             'image_file_id',
+            'image',
             'sideboxes' => [
                 '*' => [
                     'title',
@@ -1496,6 +1517,13 @@ class CollectionCategoriesTest extends TestCase
             'name' => 'Test Category',
             'intro' => 'Lorem ipsum',
             'image_file_id' => $image->id,
+            'image' => [
+                'id' => $image->id,
+                'mime_type' => $image->mime_type,
+                'alt_text' => $image->meta['alt_text'],
+                'created_at' => $image->created_at->format(CarbonImmutable::ISO8601),
+                'updated_at' => $image->updated_at->format(CarbonImmutable::ISO8601),
+            ],
             'order' => 1,
             'enabled' => true,
             'homepage' => false,
@@ -1637,16 +1665,23 @@ class CollectionCategoriesTest extends TestCase
 
         $response->assertStatus(Response::HTTP_OK);
 
+        $response->assertJsonFragment([
+            'image' => [
+                'id' => $image->id,
+                'mime_type' => $image->mime_type,
+                'alt_text' => $image->meta['alt_text'],
+                'created_at' => $image->created_at->format(CarbonImmutable::ISO8601),
+                'updated_at' => $image->updated_at->format(CarbonImmutable::ISO8601),
+            ],
+        ]);
+
         $category = $category->fresh();
         $this->assertEquals($image->id, $category->meta['image_file_id']);
 
         $content = $this->get("/core/v1/collections/categories/{$category->id}/image.svg")->content();
         $this->assertEquals(Storage::disk('local')->get('/test-data/image.svg'), $content);
 
-        $this->assertDatabaseHas($image->getTable(), [
-            'id' => $image->id,
-            'meta' => null,
-        ]);
+        $this->assertFalse($image->fresh()->pendingAssignment);
 
         // PNG
         $image = File::factory()->pendingAssignment()->imagePng()->create();
@@ -1665,16 +1700,23 @@ class CollectionCategoriesTest extends TestCase
 
         $response->assertStatus(Response::HTTP_OK);
 
+        $response->assertJsonFragment([
+            'image' => [
+                'id' => $image->id,
+                'mime_type' => $image->mime_type,
+                'alt_text' => $image->meta['alt_text'],
+                'created_at' => $image->created_at->format(CarbonImmutable::ISO8601),
+                'updated_at' => $image->updated_at->format(CarbonImmutable::ISO8601),
+            ],
+        ]);
+
         $category = $category->fresh();
         $this->assertEquals($image->id, $category->meta['image_file_id']);
 
         $content = $this->get("/core/v1/collections/categories/{$category->id}/image.png")->content();
         $this->assertEquals(Storage::disk('local')->get('/test-data/image.png'), $content);
 
-        $this->assertDatabaseHas($image->getTable(), [
-            'id' => $image->id,
-            'meta' => null,
-        ]);
+        $this->assertFalse($image->fresh()->pendingAssignment);
 
         // JPG
         $image = File::factory()->pendingAssignment()->imageJpg()->create();
@@ -1693,16 +1735,23 @@ class CollectionCategoriesTest extends TestCase
 
         $response->assertStatus(Response::HTTP_OK);
 
+        $response->assertJsonFragment([
+            'image' => [
+                'id' => $image->id,
+                'mime_type' => $image->mime_type,
+                'alt_text' => $image->meta['alt_text'],
+                'created_at' => $image->created_at->format(CarbonImmutable::ISO8601),
+                'updated_at' => $image->updated_at->format(CarbonImmutable::ISO8601),
+            ],
+        ]);
+
         $category = $category->fresh();
         $this->assertEquals($image->id, $category->meta['image_file_id']);
 
         $content = $this->get("/core/v1/collections/categories/{$category->id}/image.jpg")->content();
         $this->assertEquals(Storage::disk('local')->get('/test-data/image.jpg'), $content);
 
-        $this->assertDatabaseHas($image->getTable(), [
-            'id' => $image->id,
-            'meta' => null,
-        ]);
+        $this->assertFalse($image->fresh()->pendingAssignment);
     }
 
     /**
@@ -1820,6 +1869,7 @@ class CollectionCategoriesTest extends TestCase
             'enabled',
             'homepage',
             'image_file_id',
+            'image',
             'sideboxes' => [
                 '*' => [
                     'title',
@@ -1864,10 +1914,7 @@ class CollectionCategoriesTest extends TestCase
         $category->addToHomepage()->save();
         $taxonomy = Taxonomy::category()->children()->inRandomOrder()->firstOrFail();
 
-        $image = File::factory()->pendingAssignment()->create([
-            'filename' => Str::random() . '.svg',
-            'mime_type' => 'image/svg+xml',
-        ]);
+        $image = File::factory()->pendingAssignment()->imageSvg()->create();
 
         $base64Image = 'data:image/svg+xml;base64,' . base64_encode(Storage::disk('local')->get('/test-data/image.svg'));
 
@@ -1894,6 +1941,7 @@ class CollectionCategoriesTest extends TestCase
             'name',
             'intro',
             'image_file_id',
+            'image',
             'order',
             'enabled',
             'homepage',
@@ -1919,6 +1967,13 @@ class CollectionCategoriesTest extends TestCase
             'name' => 'Test Category',
             'intro' => 'Lorem ipsum',
             'image_file_id' => $image->id,
+            'image' => [
+                'id' => $image->id,
+                'mime_type' => $image->mime_type,
+                'alt_text' => $image->meta['alt_text'],
+                'created_at' => $image->created_at->format(CarbonImmutable::ISO8601),
+                'updated_at' => $image->updated_at->format(CarbonImmutable::ISO8601),
+            ],
             'order' => 1,
             'enabled' => true,
             'homepage' => false,

--- a/tests/Feature/CollectionCategoriesTest.php
+++ b/tests/Feature/CollectionCategoriesTest.php
@@ -627,8 +627,6 @@ class CollectionCategoriesTest extends TestCase
                 'id' => $image->id,
                 'mime_type' => $image->mime_type,
                 'alt_text' => $image->meta['alt_text'],
-                'created_at' => $image->created_at->format(CarbonImmutable::ISO8601),
-                'updated_at' => $image->updated_at->format(CarbonImmutable::ISO8601),
             ],
         ]);
 
@@ -666,8 +664,6 @@ class CollectionCategoriesTest extends TestCase
                 'id' => $image->id,
                 'mime_type' => $image->mime_type,
                 'alt_text' => $image->meta['alt_text'],
-                'created_at' => $image->created_at->format(CarbonImmutable::ISO8601),
-                'updated_at' => $image->updated_at->format(CarbonImmutable::ISO8601),
             ],
         ]);
 
@@ -705,8 +701,6 @@ class CollectionCategoriesTest extends TestCase
                 'id' => $image->id,
                 'mime_type' => $image->mime_type,
                 'alt_text' => $image->meta['alt_text'],
-                'created_at' => $image->created_at->format(CarbonImmutable::ISO8601),
-                'updated_at' => $image->updated_at->format(CarbonImmutable::ISO8601),
             ],
         ]);
 
@@ -1521,8 +1515,6 @@ class CollectionCategoriesTest extends TestCase
                 'id' => $image->id,
                 'mime_type' => $image->mime_type,
                 'alt_text' => $image->meta['alt_text'],
-                'created_at' => $image->created_at->format(CarbonImmutable::ISO8601),
-                'updated_at' => $image->updated_at->format(CarbonImmutable::ISO8601),
             ],
             'order' => 1,
             'enabled' => true,
@@ -1670,8 +1662,6 @@ class CollectionCategoriesTest extends TestCase
                 'id' => $image->id,
                 'mime_type' => $image->mime_type,
                 'alt_text' => $image->meta['alt_text'],
-                'created_at' => $image->created_at->format(CarbonImmutable::ISO8601),
-                'updated_at' => $image->updated_at->format(CarbonImmutable::ISO8601),
             ],
         ]);
 
@@ -1705,8 +1695,6 @@ class CollectionCategoriesTest extends TestCase
                 'id' => $image->id,
                 'mime_type' => $image->mime_type,
                 'alt_text' => $image->meta['alt_text'],
-                'created_at' => $image->created_at->format(CarbonImmutable::ISO8601),
-                'updated_at' => $image->updated_at->format(CarbonImmutable::ISO8601),
             ],
         ]);
 
@@ -1740,8 +1728,6 @@ class CollectionCategoriesTest extends TestCase
                 'id' => $image->id,
                 'mime_type' => $image->mime_type,
                 'alt_text' => $image->meta['alt_text'],
-                'created_at' => $image->created_at->format(CarbonImmutable::ISO8601),
-                'updated_at' => $image->updated_at->format(CarbonImmutable::ISO8601),
             ],
         ]);
 
@@ -1971,8 +1957,6 @@ class CollectionCategoriesTest extends TestCase
                 'id' => $image->id,
                 'mime_type' => $image->mime_type,
                 'alt_text' => $image->meta['alt_text'],
-                'created_at' => $image->created_at->format(CarbonImmutable::ISO8601),
-                'updated_at' => $image->updated_at->format(CarbonImmutable::ISO8601),
             ],
             'order' => 1,
             'enabled' => true,

--- a/tests/Feature/CollectionOrganisationEventsTest.php
+++ b/tests/Feature/CollectionOrganisationEventsTest.php
@@ -61,6 +61,7 @@ class CollectionOrganisationEventsTest extends TestCase
             'order',
             'enabled',
             'image_file_id',
+            'image',
             'sideboxes' => [
                 '*' => [
                     'title',
@@ -102,6 +103,7 @@ class CollectionOrganisationEventsTest extends TestCase
                     'name',
                     'intro',
                     'image_file_id',
+                    'image',
                     'order',
                     'enabled',
                     'sideboxes' => [
@@ -327,6 +329,11 @@ class CollectionOrganisationEventsTest extends TestCase
             'name',
             'intro',
             'image_file_id',
+            'image' => [
+                'id',
+                'mime_type',
+                'alt_text',
+            ],
             'order',
             'enabled',
             'sideboxes' => [
@@ -356,6 +363,13 @@ class CollectionOrganisationEventsTest extends TestCase
         ]);
         $response->assertJsonFragment([
             'id' => $randomCategory->id,
+        ]);
+        $response->assertJsonFragment([
+            'image' => [
+                'id' => $image->id,
+                'mime_type' => $image->mime_type,
+                'alt_text' => $image->meta['alt_text'],
+            ],
         ]);
 
         $collectionArray = $this->getResponseContent($response)['data'];
@@ -769,16 +783,21 @@ class CollectionOrganisationEventsTest extends TestCase
 
         $response->assertStatus(Response::HTTP_CREATED);
 
+        $response->assertJsonFragment([
+            'image' => [
+                'id' => $image->id,
+                'mime_type' => $image->mime_type,
+                'alt_text' => $image->meta['alt_text'],
+            ],
+        ]);
+
         $collectionArray = $this->getResponseContent($response)['data'];
         $response = $this->get("/core/v1/collections/organisation-events/{$collectionArray['id']}/image.svg");
         $this->assertEquals(Storage::disk('local')->get('/test-data/image.svg'), $response->content());
 
         $this->assertEquals($image->id, $collectionArray['image_file_id']);
 
-        $this->assertDatabaseHas($image->getTable(), [
-            'id' => $image->id,
-            'meta' => null,
-        ]);
+        $this->assertFalse($image->fresh()->pendingAssignment);
 
         // PNG
         $image = File::factory()->pendingAssignment()->imagePng()->create();
@@ -795,16 +814,21 @@ class CollectionOrganisationEventsTest extends TestCase
 
         $response->assertStatus(Response::HTTP_CREATED);
 
+        $response->assertJsonFragment([
+            'image' => [
+                'id' => $image->id,
+                'mime_type' => $image->mime_type,
+                'alt_text' => $image->meta['alt_text'],
+            ],
+        ]);
+
         $collectionArray = $this->getResponseContent($response)['data'];
         $response = $this->get("/core/v1/collections/organisation-events/{$collectionArray['id']}/image.png");
         $this->assertEquals(Storage::disk('local')->get('/test-data/image.png'), $response->content());
 
         $this->assertEquals($image->id, $collectionArray['image_file_id']);
 
-        $this->assertDatabaseHas($image->getTable(), [
-            'id' => $image->id,
-            'meta' => null,
-        ]);
+        $this->assertFalse($image->fresh()->pendingAssignment);
 
         // JPG
         $image = File::factory()->pendingAssignment()->imageJpg()->create();
@@ -821,16 +845,21 @@ class CollectionOrganisationEventsTest extends TestCase
 
         $response->assertStatus(Response::HTTP_CREATED);
 
+        $response->assertJsonFragment([
+            'image' => [
+                'id' => $image->id,
+                'mime_type' => $image->mime_type,
+                'alt_text' => $image->meta['alt_text'],
+            ],
+        ]);
+
         $collectionArray = $this->getResponseContent($response)['data'];
         $response = $this->get("/core/v1/collections/organisation-events/{$collectionArray['id']}/image.jpg");
         $this->assertEquals(Storage::disk('local')->get('/test-data/image.jpg'), $response->content());
 
         $this->assertEquals($image->id, $collectionArray['image_file_id']);
 
-        $this->assertDatabaseHas($image->getTable(), [
-            'id' => $image->id,
-            'meta' => null,
-        ]);
+        $this->assertFalse($image->fresh()->pendingAssignment);
     }
 
     /**
@@ -1548,10 +1577,15 @@ class CollectionOrganisationEventsTest extends TestCase
         $content = $this->get("/core/v1/collections/organisation-events/{$organisationEvent->id}/image.svg")->content();
         $this->assertEquals(Storage::disk('local')->get('/test-data/image.svg'), $content);
 
-        $this->assertDatabaseHas($image->getTable(), [
-            'id' => $image->id,
-            'meta' => null,
+        $response->assertJsonFragment([
+            'image' => [
+                'id' => $image->id,
+                'mime_type' => $image->mime_type,
+                'alt_text' => $image->meta['alt_text'],
+            ],
         ]);
+
+        $this->assertFalse($image->fresh()->pendingAssignment);
 
         // PNG
         $image = File::factory()->pendingAssignment()->imagePng()->create();
@@ -1574,10 +1608,15 @@ class CollectionOrganisationEventsTest extends TestCase
         $content = $this->get("/core/v1/collections/organisation-events/{$organisationEvent->id}/image.png")->content();
         $this->assertEquals(Storage::disk('local')->get('/test-data/image.png'), $content);
 
-        $this->assertDatabaseHas($image->getTable(), [
-            'id' => $image->id,
-            'meta' => null,
+        $response->assertJsonFragment([
+            'image' => [
+                'id' => $image->id,
+                'mime_type' => $image->mime_type,
+                'alt_text' => $image->meta['alt_text'],
+            ],
         ]);
+
+        $this->assertFalse($image->fresh()->pendingAssignment);
 
         // JPG
         $image = File::factory()->pendingAssignment()->imageJpg()->create();
@@ -1600,10 +1639,15 @@ class CollectionOrganisationEventsTest extends TestCase
         $content = $this->get("/core/v1/collections/organisation-events/{$organisationEvent->id}/image.jpg")->content();
         $this->assertEquals(Storage::disk('local')->get('/test-data/image.jpg'), $content);
 
-        $this->assertDatabaseHas($image->getTable(), [
-            'id' => $image->id,
-            'meta' => null,
+        $response->assertJsonFragment([
+            'image' => [
+                'id' => $image->id,
+                'mime_type' => $image->mime_type,
+                'alt_text' => $image->meta['alt_text'],
+            ],
         ]);
+
+        $this->assertFalse($image->fresh()->pendingAssignment);
     }
 
     /**
@@ -2011,8 +2055,10 @@ class CollectionOrganisationEventsTest extends TestCase
         $imageResponse = $this->json('POST', '/core/v1/files', [
             'is_private' => false,
             'mime_type' => 'image/png',
+            'alt_text' => 'image description',
             'file' => 'data:image/png;base64,' . base64_encode($image),
         ]);
+        $imageResponse->assertStatus(Response::HTTP_CREATED);
 
         $response = $this->json('POST', '/core/v1/collections/organisation-events', [
             'name' => 'Test Organisation Event',
@@ -2028,6 +2074,14 @@ class CollectionOrganisationEventsTest extends TestCase
         $collectionArray = $this->getResponseContent($response)['data'];
         $content = $this->get("/core/v1/collections/organisation-events/{$collectionArray['id']}/image.png")->content();
         $this->assertEquals($image, $content);
+
+        $response->assertJsonFragment([
+            'image' => [
+                'id' => $this->getResponseContent($imageResponse, 'data.id'),
+                'mime_type' => 'image/png',
+                'alt_text' => 'image description',
+            ],
+        ]);
     }
 
     /*

--- a/tests/Feature/FilesTest.php
+++ b/tests/Feature/FilesTest.php
@@ -3,8 +3,10 @@
 namespace Tests\Feature;
 
 use Tests\TestCase;
+use App\Models\File;
 use App\Models\User;
 use App\Models\Service;
+use Carbon\CarbonImmutable;
 use Illuminate\Http\Response;
 use Laravel\Passport\Passport;
 use Illuminate\Support\Facades\Storage;
@@ -25,6 +27,7 @@ class FilesTest extends TestCase
         $response = $this->json('POST', '/core/v1/files', [
             'is_private' => false,
             'mime_type' => 'image/png',
+            'alt_text' => 'image description',
             'file' => 'data:image/png;base64,' . base64_encode($image),
         ]);
 
@@ -46,6 +49,7 @@ class FilesTest extends TestCase
         $response = $this->json('POST', '/core/v1/files', [
             'is_private' => false,
             'mime_type' => 'image/png',
+            'alt_text' => 'image description',
             'file' => 'data:image/png;base64,' . base64_encode($image),
         ]);
 
@@ -57,6 +61,21 @@ class FilesTest extends TestCase
         $response = $this->get("/core/v1/services/$service->id/logo.png");
 
         $this->assertEquals($image, $response->content());
+
+        $response = $this->get("/core/v1/files/$service->logo_file_id");
+
+        $response->assertJson([
+            'data' => [
+                'id' => $service->logoFile->id,
+                'is_private' => false,
+                'mime_type' => 'image/png',
+                'alt_text' => 'image description',
+                'max_dimension' => null,
+                'src' => 'data:image/png;base64,' . base64_encode($image),
+                'created_at' => $service->logoFile->created_at->format(CarbonImmutable::ISO8601),
+                'updated_at' => $service->logoFile->updated_at->format(CarbonImmutable::ISO8601),
+            ],
+        ]);
     }
 
     /**
@@ -74,6 +93,7 @@ class FilesTest extends TestCase
         $response = $this->json('POST', '/core/v1/files', [
             'is_private' => false,
             'mime_type' => 'image/jpeg',
+            'alt_text' => 'image description',
             'file' => 'data:image/jpeg;base64,' . base64_encode($image),
         ]);
 
@@ -85,5 +105,195 @@ class FilesTest extends TestCase
         $response = $this->get("/core/v1/services/$service->id/logo.jpg");
 
         $this->assertEquals($image, $response->content());
+
+        $response = $this->get("/core/v1/files/$service->logo_file_id");
+
+        $response->assertJson([
+            'data' => [
+                'id' => $service->logoFile->id,
+                'is_private' => false,
+                'mime_type' => 'image/jpeg',
+                'alt_text' => 'image description',
+                'max_dimension' => null,
+                'src' => 'data:image/jpeg;base64,' . base64_encode($image),
+                'created_at' => $service->logoFile->created_at->format(CarbonImmutable::ISO8601),
+                'updated_at' => $service->logoFile->updated_at->format(CarbonImmutable::ISO8601),
+            ],
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function createSvgFileAsServiceAdmin201(): void
+    {
+        $image = Storage::disk('local')->get('/test-data/image.svg');
+
+        $service = Service::factory()->create();
+        $user = User::factory()->create()->makeServiceAdmin($service);
+
+        Passport::actingAs($user);
+
+        $response = $this->json('POST', '/core/v1/files', [
+            'is_private' => false,
+            'mime_type' => 'image/svg+xml',
+            'alt_text' => 'image description',
+            'file' => 'data:image/svg+xml;base64,' . base64_encode($image),
+        ]);
+
+        $response->assertStatus(Response::HTTP_CREATED);
+
+        $service->logo_file_id = $this->getResponseContent($response, 'data.id');
+        $service->save();
+
+        $response = $this->get("/core/v1/services/$service->id/logo.svg");
+
+        $this->assertEquals($image, $response->content());
+        $response = $this->get("/core/v1/files/$service->logo_file_id");
+
+        $response->assertJson([
+            'data' => [
+                'id' => $service->logoFile->id,
+                'is_private' => false,
+                'mime_type' => 'image/svg+xml',
+                'alt_text' => 'image description',
+                'max_dimension' => null,
+                'src' => 'data:image/svg+xml;base64,' . base64_encode($image),
+                'created_at' => $service->logoFile->created_at->format(CarbonImmutable::ISO8601),
+                'updated_at' => $service->logoFile->updated_at->format(CarbonImmutable::ISO8601),
+            ],
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function createImageFileAltTextRequiredAsServiceAdmin201(): void
+    {
+        $image = Storage::disk('local')->get('/test-data/image.png');
+
+        $service = Service::factory()->create();
+        $user = User::factory()->create()->makeServiceAdmin($service);
+
+        Passport::actingAs($user);
+
+        $response = $this->json('POST', '/core/v1/files', [
+            'is_private' => false,
+            'mime_type' => 'image/png',
+            'file' => 'data:image/png;base64,' . base64_encode($image),
+        ]);
+
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+
+        $response = $this->json('POST', '/core/v1/files', [
+            'is_private' => false,
+            'mime_type' => 'image/png',
+            'alt_text' => '',
+            'file' => 'data:image/png;base64,' . base64_encode($image),
+        ]);
+
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+
+        $response = $this->json('POST', '/core/v1/files', [
+            'is_private' => false,
+            'mime_type' => 'image/jpeg',
+            'alt_text' => '',
+            'file' => 'data:image/jpeg;base64,' . base64_encode($image),
+        ]);
+
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+
+        $response = $this->json('POST', '/core/v1/files', [
+            'is_private' => false,
+            'mime_type' => 'image/svg+xml',
+            'alt_text' => '',
+            'file' => 'data:image/svg+xml;base64,' . base64_encode($image),
+        ]);
+
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    /**
+     * @test
+     */
+    public function getPngFileAsGuest200()
+    {
+        $image = File::factory()->pendingAssignment()->imagePng()->create();
+        $service = Service::factory()->create([
+            'logo_file_id' => $image->id,
+        ]);
+
+        $response = $this->get("/core/v1/files/$image->id");
+
+        $response->assertJson([
+            'data' => [
+                'id' => $image->id,
+                'is_private' => $image->is_private,
+                'mime_type' => $image->mime_type,
+                'alt_text' => $image->meta['alt_text'],
+                'max_dimension' => null,
+                'src' => 'data:image/png;base64,' . base64_encode($image->getContent()),
+                'created_at' => $image->created_at->format(CarbonImmutable::ISO8601),
+                'updated_at' => $image->updated_at->format(CarbonImmutable::ISO8601),
+            ],
+        ]);
+
+        $this->assertEquals('data:image/png;base64,' . base64_encode(Storage::disk('local')->get('/test-data/image.png')), $response->json('data.src'));
+    }
+
+    /**
+     * @test
+     */
+    public function getJpgFileAsGuest200()
+    {
+        $image = File::factory()->pendingAssignment()->imageJpg()->create();
+        $service = Service::factory()->create([
+            'logo_file_id' => $image->id,
+        ]);
+
+        $response = $this->get("/core/v1/files/$image->id");
+
+        $response->assertJson([
+            'data' => [
+                'id' => $image->id,
+                'is_private' => $image->is_private,
+                'mime_type' => $image->mime_type,
+                'alt_text' => $image->meta['alt_text'],
+                'max_dimension' => null,
+                'src' => 'data:image/jpeg;base64,' . base64_encode($image->getContent()),
+                'created_at' => $image->created_at->format(CarbonImmutable::ISO8601),
+                'updated_at' => $image->updated_at->format(CarbonImmutable::ISO8601),
+            ],
+        ]);
+
+        $this->assertEquals('data:image/jpeg;base64,' . base64_encode(Storage::disk('local')->get('/test-data/image.jpg')), $response->json('data.src'));
+    }
+
+    /**
+     * @test
+     */
+    public function getSvgFileAsGuest200()
+    {
+        $image = File::factory()->pendingAssignment()->imageSvg()->create();
+        $service = Service::factory()->create([
+            'logo_file_id' => $image->id,
+        ]);
+
+        $response = $this->get("/core/v1/files/$image->id");
+
+        $response->assertJson([
+            'data' => [
+                'id' => $image->id,
+                'is_private' => $image->is_private,
+                'mime_type' => $image->mime_type,
+                'alt_text' => $image->meta['alt_text'],
+                'max_dimension' => null,
+                'src' => 'data:image/svg+xml;base64,' . base64_encode($image->getContent()),
+                'created_at' => $image->created_at->format(CarbonImmutable::ISO8601),
+                'updated_at' => $image->updated_at->format(CarbonImmutable::ISO8601),
+            ],
+        ]);
+
+        $this->assertEquals('data:image/svg+xml;base64,' . base64_encode(Storage::disk('local')->get('/test-data/image.svg')), $response->json('data.src'));
     }
 }

--- a/tests/Feature/LocationsTest.php
+++ b/tests/Feature/LocationsTest.php
@@ -28,7 +28,7 @@ class LocationsTest extends TestCase
      */
     public function guest_can_list_them(): void
     {
-        $location = Location::factory()->create();
+        $location = Location::factory()->withJpgImage()->create();
 
         $response = $this->json('GET', '/core/v1/locations');
 
@@ -45,6 +45,7 @@ class LocationsTest extends TestCase
             'country',
             'lat',
             'lon',
+            'image',
             'accessibility_info',
             'has_wheelchair_access',
             'has_induction_loop',
@@ -64,6 +65,11 @@ class LocationsTest extends TestCase
             'country' => $location->country,
             'lat' => $location->lat,
             'lon' => $location->lon,
+            'image' => [
+                'id' => $location->imageFile->id,
+                'mime_type' => $location->imageFile->mime_type,
+                'alt_text' => $location->imageFile->altText,
+            ],
             'accessibility_info' => $location->accessibility_info,
             'has_wheelchair_access' => $location->has_wheelchair_access,
             'has_induction_loop' => $location->has_induction_loop,
@@ -160,6 +166,7 @@ class LocationsTest extends TestCase
             'county' => 'West Yorkshire',
             'postcode' => 'LS1 4HT',
             'country' => 'England',
+            'image' => null,
             'accessibility_info' => null,
             'has_wheelchair_access' => false,
             'has_induction_loop' => false,
@@ -205,6 +212,7 @@ class LocationsTest extends TestCase
             'county' => 'West Yorkshire',
             'postcode' => 'LS1 4HT',
             'country' => 'England',
+            'image' => null,
             'accessibility_info' => null,
             'has_wheelchair_access' => false,
             'has_induction_loop' => false,
@@ -241,12 +249,18 @@ class LocationsTest extends TestCase
         $locationId = $this->getResponseContent($response, 'data.id');
 
         $response->assertStatus(Response::HTTP_CREATED);
+
+        $response->assertJsonFragment([
+            'image' => [
+                'id' => $image->id,
+                'mime_type' => $image->mime_type,
+                'alt_text' => $image->meta['alt_text'],
+            ],
+        ]);
+
         $this->assertDatabaseHas(table(Location::class), [
             'id' => $locationId,
-        ]);
-        $this->assertDatabaseMissing(table(Location::class), [
-            'id' => $locationId,
-            'image_file_id' => null,
+            'image_file_id' => $image->id,
         ]);
 
         $response = $this->get("/core/v1/locations/{$locationId}/image.jpg");
@@ -339,7 +353,7 @@ class LocationsTest extends TestCase
      */
     public function guest_can_view_one(): void
     {
-        $location = Location::factory()->create();
+        $location = Location::factory()->withJpgImage()->create();
 
         $response = $this->json('GET', "/core/v1/locations/{$location->id}");
 
@@ -356,6 +370,11 @@ class LocationsTest extends TestCase
             'country' => $location->country,
             'lat' => $location->lat,
             'lon' => $location->lon,
+            'image' => [
+                'id' => $location->imageFile->id,
+                'mime_type' => $location->imageFile->mime_type,
+                'alt_text' => $location->imageFile->alt_text,
+            ],
             'accessibility_info' => $location->accessibility_info,
             'has_wheelchair_access' => $location->has_wheelchair_access,
             'has_induction_loop' => $location->has_induction_loop,

--- a/tests/Feature/OrganisationEventsTest.php
+++ b/tests/Feature/OrganisationEventsTest.php
@@ -34,7 +34,7 @@ class OrganisationEventsTest extends TestCase
      */
     public function listOrganisationEventsAsGuest200(): void
     {
-        $organisationEvent = OrganisationEvent::factory()->create();
+        $organisationEvent = OrganisationEvent::factory()->withImage()->create();
 
         $response = $this->json('GET', '/core/v1/organisation-events');
 
@@ -49,6 +49,7 @@ class OrganisationEventsTest extends TestCase
             'end_time',
             'intro',
             'description',
+            'image',
             'is_free',
             'fees_text',
             'fees_url',
@@ -78,6 +79,11 @@ class OrganisationEventsTest extends TestCase
             'end_time' => $organisationEvent->end_time,
             'intro' => $organisationEvent->intro,
             'description' => $organisationEvent->description,
+            'image' => [
+                'id' => $organisationEvent->imageFile->id,
+                'mime_type' => $organisationEvent->imageFile->mime_type,
+                'alt_text' => $organisationEvent->imageFile->meta['alt_text'],
+            ],
             'is_free' => $organisationEvent->is_free,
             'fees_text' => $organisationEvent->fees_text,
             'fees_url' => $organisationEvent->fees_url,
@@ -700,8 +706,6 @@ class OrganisationEventsTest extends TestCase
 
         $response->assertJsonFragment($payload);
 
-        $responseData = json_decode($response->getContent());
-
         //Then an update request should be created for the new event
         $updateRequest = UpdateRequest::findOrFail($response->json('id'));
 
@@ -1298,8 +1302,10 @@ class OrganisationEventsTest extends TestCase
         $imageResponse = $this->json('POST', '/core/v1/files', [
             'is_private' => false,
             'mime_type' => 'image/png',
+            'alt_text' => 'image description',
             'file' => 'data:image/png;base64,' . base64_encode($image),
         ]);
+        $imageResponse->assertStatus(Response::HTTP_CREATED);
 
         $date = $this->faker->dateTimeBetween('tomorrow', '+6 weeks')->format('Y-m-d');
         $payload = [
@@ -1366,8 +1372,10 @@ class OrganisationEventsTest extends TestCase
         $imageResponse = $this->json('POST', '/core/v1/files', [
             'is_private' => false,
             'mime_type' => 'image/png',
+            'alt_text' => 'image description',
             'file' => 'data:image/png;base64,' . base64_encode($image),
         ]);
+        $imageResponse->assertStatus(Response::HTTP_CREATED);
 
         $date = $this->faker->dateTimeBetween('tomorrow', '+6 weeks')->format('Y-m-d');
         $payload = [
@@ -1957,7 +1965,7 @@ class OrganisationEventsTest extends TestCase
      */
     public function getSingleOrganisationEventAsGuest200(): void
     {
-        $organisationEvent = OrganisationEvent::factory()->create();
+        $organisationEvent = OrganisationEvent::factory()->withImage()->create();
 
         $response = $this->json('GET', "/core/v1/organisation-events/{$organisationEvent->id}");
 
@@ -1973,6 +1981,11 @@ class OrganisationEventsTest extends TestCase
             'end_time' => $organisationEvent->end_time,
             'intro' => $organisationEvent->intro,
             'description' => $organisationEvent->description,
+            'image' => [
+                'id' => $organisationEvent->imageFile->id,
+                'mime_type' => $organisationEvent->imageFile->mime_type,
+                'alt_text' => $organisationEvent->imageFile->meta['alt_text'],
+            ],
             'is_free' => $organisationEvent->is_free,
             'fees_text' => $organisationEvent->fees_text,
             'fees_url' => $organisationEvent->fees_url,
@@ -2018,6 +2031,7 @@ class OrganisationEventsTest extends TestCase
             'end_time' => $organisationEvent->end_time,
             'intro' => $organisationEvent->intro,
             'description' => $organisationEvent->description,
+            'image' => null,
             'is_free' => $organisationEvent->is_free,
             'fees_text' => $organisationEvent->fees_text,
             'fees_url' => $organisationEvent->fees_url,
@@ -2461,8 +2475,11 @@ class OrganisationEventsTest extends TestCase
         $imageResponse = $this->json('POST', '/core/v1/files', [
             'is_private' => false,
             'mime_type' => 'image/png',
+            'alt_text' => 'image description',
             'file' => 'data:image/png;base64,' . base64_encode($image),
         ]);
+
+        $imageResponse->assertStatus(Response::HTTP_CREATED);
 
         $organisationEvent = OrganisationEvent::factory()->create();
 

--- a/tests/Feature/OrganisationsTest.php
+++ b/tests/Feature/OrganisationsTest.php
@@ -61,7 +61,7 @@ class OrganisationsTest extends TestCase
      */
     public function guest_can_list_them(): void
     {
-        $organisation = Organisation::factory()->create();
+        $organisation = Organisation::factory()->withPngLogo()->create();
 
         $response = $this->json('GET', '/core/v1/organisations');
 
@@ -73,6 +73,11 @@ class OrganisationsTest extends TestCase
                 'slug' => $organisation->slug,
                 'name' => $organisation->name,
                 'description' => $organisation->description,
+                'image' => [
+                    'id' => $organisation->logoFile->id,
+                    'mime_type' => $organisation->logoFile->mime_type,
+                    'alt_text' => $organisation->logoFile->altText,
+                ],
                 'url' => $organisation->url,
                 'email' => $organisation->email,
                 'phone' => $organisation->phone,
@@ -593,7 +598,7 @@ class OrganisationsTest extends TestCase
      */
     public function guest_can_view_one(): void
     {
-        $organisation = Organisation::factory()->create();
+        $organisation = Organisation::factory()->withPngLogo()->create();
 
         $organisation->socialMedias()->create([
             'type' => SocialMedia::TYPE_INSTAGRAM,
@@ -610,6 +615,11 @@ class OrganisationsTest extends TestCase
                 'slug' => $organisation->slug,
                 'name' => $organisation->name,
                 'description' => $organisation->description,
+                'image' => [
+                    'id' => $organisation->logoFile->id,
+                    'mime_type' => $organisation->logoFile->mime_type,
+                    'alt_text' => $organisation->logoFile->altText,
+                ],
                 'url' => $organisation->url,
                 'email' => $organisation->email,
                 'phone' => $organisation->phone,
@@ -643,6 +653,7 @@ class OrganisationsTest extends TestCase
                 'slug' => $organisation->slug,
                 'name' => $organisation->name,
                 'description' => $organisation->description,
+                'image' => null,
                 'url' => $organisation->url,
                 'email' => $organisation->email,
                 'phone' => $organisation->phone,
@@ -1541,8 +1552,10 @@ class OrganisationsTest extends TestCase
         $imageResponse = $this->json('POST', '/core/v1/files', [
             'is_private' => false,
             'mime_type' => 'image/png',
+            'alt_text' => 'image description',
             'file' => 'data:image/png;base64,' . base64_encode($image),
         ]);
+        $imageResponse->assertStatus(Response::HTTP_CREATED);
 
         $response = $this->json('POST', '/core/v1/organisations', [
             'slug' => 'test-org',

--- a/tests/Feature/PagesTest.php
+++ b/tests/Feature/PagesTest.php
@@ -2609,8 +2609,7 @@ class PagesTest extends TestCase
             'image' => [
                 'id',
                 'mime_type',
-                'created_at',
-                'updated_at',
+                'alt_text',
             ],
             'landing_page',
             'children' => [
@@ -2661,8 +2660,7 @@ class PagesTest extends TestCase
             'image' => [
                 'id',
                 'mime_type',
-                'created_at',
-                'updated_at',
+                'alt_text',
             ],
             'landing_page',
             'parent',
@@ -2726,8 +2724,7 @@ class PagesTest extends TestCase
             'image' => [
                 'id',
                 'mime_type',
-                'created_at',
-                'updated_at',
+                'alt_text',
             ],
             'children' => [
                 '*' => [
@@ -2819,8 +2816,7 @@ class PagesTest extends TestCase
             'image' => [
                 'id',
                 'mime_type',
-                'created_at',
-                'updated_at',
+                'alt_text',
             ],
             'landing_page',
             'children' => [

--- a/tests/Feature/ServiceLocationsTest.php
+++ b/tests/Feature/ServiceLocationsTest.php
@@ -776,6 +776,7 @@ class ServiceLocationsTest extends TestCase
         $imageResponse = $this->json('POST', '/core/v1/files', [
             'is_private' => false,
             'mime_type' => 'image/png',
+            'alt_text' => 'image description',
             'file' => 'data:image/png;base64,' . base64_encode($image),
         ]);
 

--- a/tests/Feature/SettingsTest.php
+++ b/tests/Feature/SettingsTest.php
@@ -2,18 +2,18 @@
 
 namespace Tests\Feature;
 
-use App\Events\EndpointHit;
+use Tests\TestCase;
+use App\Models\User;
 use App\Models\Audit;
-use App\Models\Organisation;
 use App\Models\Service;
 use App\Models\Setting;
-use App\Models\User;
-use Illuminate\Http\Response;
+use App\Events\EndpointHit;
 use Illuminate\Support\Arr;
+use App\Models\Organisation;
+use Illuminate\Http\Response;
+use Laravel\Passport\Passport;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
-use Laravel\Passport\Passport;
-use Tests\TestCase;
 
 class SettingsTest extends TestCase
 {
@@ -484,7 +484,8 @@ class SettingsTest extends TestCase
         $imageResponse = $this->json('POST', '/core/v1/files', [
             'is_private' => false,
             'mime_type' => 'image/png',
-            'file' => 'data:image/png;base64,'.base64_encode($image),
+            'alt_text' => 'image description',
+            'file' => 'data:image/png;base64,' . base64_encode($image),
         ]);
 
         $this->settingsData['cms']['frontend']['banner']['image_file_id'] = $this->getResponseContent($imageResponse, 'data.id');
@@ -548,7 +549,7 @@ class SettingsTest extends TestCase
         $this->json('POST', '/core/v1/files', [
             'is_private' => false,
             'mime_type' => 'image/png',
-            'file' => 'data:image/png;base64,'.base64_encode($image),
+            'file' => 'data:image/png;base64,' . base64_encode($image),
         ]);
 
         $this->settingsData['cms']['frontend']['banner'] = [
@@ -584,7 +585,8 @@ class SettingsTest extends TestCase
         $imageResponse = $this->json('POST', '/core/v1/files', [
             'is_private' => false,
             'mime_type' => 'image/png',
-            'file' => 'data:image/png;base64,'.base64_encode($image),
+            'alt_text' => 'image description',
+            'file' => 'data:image/png;base64,' . base64_encode($image),
         ]);
 
         $cmsValue = Setting::cms()->value;
@@ -613,7 +615,7 @@ class SettingsTest extends TestCase
         $imageResponse = $this->json('POST', '/core/v1/files', [
             'is_private' => false,
             'mime_type' => 'image/png',
-            'file' => 'data:image/png;base64,'.base64_encode($image),
+            'file' => 'data:image/png;base64,' . base64_encode($image),
         ]);
 
         $cmsValue = Setting::cms()->value;

--- a/tests/Feature/UpdateRequestsTest.php
+++ b/tests/Feature/UpdateRequestsTest.php
@@ -1066,6 +1066,7 @@ class UpdateRequestsTest extends TestCase
         $imagePayload = [
             'is_private' => false,
             'mime_type' => 'image/png',
+            'alt_text' => 'image description',
             'file' => 'data:image/png;base64,' . self::BASE64_ENCODED_PNG,
         ];
 


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/4200/add-in-alt-text-fields

- Added image object to category collection response json
- Added image object to persona collection response json 
- Added image object to event collection response json 
- Added image object to organisation response json 
- Added image object to service response json
- Added image object to location response json 
- Added image object to organisation event response json 
- Updated gallery image response json, added alt_text and mime_type fields 

### Development checklist

- [x] Changes have been made to the API?
  - [x] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
