### PR TITLE
Bug/sc 4414/bug update requests corrupt when multiple

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,7 +96,7 @@ MAILGUN_SECRET=
 # USA: https://api.mailgun.net EU: https://api.eu.mailgun.net
 MAILGUN_ENDPOINT=
 
-# The SMS configuration. Select from gov, twillio, log, null
+# The SMS configuration. Select from gov, twilio, log, null
 SMS_DRIVER=log
 
 # The Twilio credentials.
@@ -131,6 +131,6 @@ API_RATE_LIMIT=300
 # Passport keys.
 # Once ./develop artisan passport:keys has been run
 # Copy and paste the contents of storage/oauth-private.key
-PASSPORT_PRIVATE_KEY=
+PASSPORT_PRIVATE_KEY=""
 # Copy and paste the contents of storage/oauth-public.key
-PASSPORT_PUBLIC_KEY=
+PASSPORT_PUBLIC_KEY=""

--- a/app/Models/Relationships/PageRelationships.php
+++ b/app/Models/Relationships/PageRelationships.php
@@ -4,8 +4,10 @@ namespace App\Models\Relationships;
 
 use App\Models\Collection;
 use App\Models\File;
+use App\Models\UpdateRequest;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Kalnoy\Nestedset\AncestorsRelation;
 
 trait PageRelationships
@@ -33,5 +35,10 @@ trait PageRelationships
     public function landingPageAncestors(): AncestorsRelation
     {
         return $this->ancestors()->where('page_type', static::PAGE_TYPE_LANDING);
+    }
+
+    public function updateRequests(): MorphMany
+    {
+        return $this->MorphMany(UpdateRequest::class, 'updateable');
     }
 }

--- a/app/Observers/PageObserver.php
+++ b/app/Observers/PageObserver.php
@@ -3,6 +3,7 @@
 namespace App\Observers;
 
 use App\Models\Page;
+use App\Models\UpdateRequest;
 
 class PageObserver
 {
@@ -17,6 +18,12 @@ class PageObserver
                 'image_file_id' => null,
             ]);
             $image->delete();
+        }
+
+        if ($page->updateRequests->isNotEmpty()) {
+            $page->updateRequests->each(function (UpdateRequest $updateRequest) {
+                $updateRequest->delete();
+            });
         }
     }
 }

--- a/app/Observers/UpdateRequestObserver.php
+++ b/app/Observers/UpdateRequestObserver.php
@@ -70,13 +70,20 @@ class UpdateRequestObserver
 
         $data = Arr::dot($updateRequest->data);
         $dataKeys = array_keys($data);
+
         foreach ($dataKeys as &$dataKey) {
             // Delete entire arrays if provided.
             $dataKey = preg_replace('/\.([0-9]+)(.*)$/', '', $dataKey);
 
+            // If a page content item is updated, then all other content updates on this page should be removed
+            if ($updateRequest->updateable_type === 'pages' && str_ends_with($dataKey, '.content')) {
+                $dataKey = 'content';
+            }
+
             // Format for MySQL.
             $dataKey = "\"$.{$dataKey}\"";
         }
+
         $dataKeys = array_unique($dataKeys);
         $implodedDataKeys = implode(', ', $dataKeys);
 


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/4414/bug-update-requests-corrupt-when-multiple-update-requests-are-made
https://app.shortcut.com/connectedplaces/story/4415/bug-update-requests-return-500-when-entity-has-been-deleted

- Orphan update requests for pages were left when a page was deleted
- `PageObserver::deleting` method removes orphan update requests
- `UpdateRequestObserver::created` method removed duplicate data keys from other update requests for the same entity. Due to the JSON format of a Page content field this was leaving empty nodes in the Page content data.
- `UpdateRequestObserver::created` method removes the whole content key from any previous Page update request if a new update request for the same entity is also updating the content

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
