### PR TITLE
All entities will delete update requests when they are deleted

### DIFF
--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -9,6 +9,7 @@ use App\Models\Mutators\PageMutators;
 use App\Models\Relationships\PageRelationships;
 use App\Models\Scopes\PageScopes;
 use App\Rules\FileIsMimeType;
+use App\UpdateRequest\UpdateRequests;
 use ElasticScoutDriverPlus\Searchable;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -23,6 +24,7 @@ class Page extends Model implements AppliesUpdateRequests
     use PageMutators;
     use PageScopes;
     use NodeTrait;
+    use UpdateRequests;
 
     /**
      * NodeTrait::usesSoftDelete and Laravel\Scout\Searchable::usesSoftDelete clash.

--- a/app/Models/Relationships/PageRelationships.php
+++ b/app/Models/Relationships/PageRelationships.php
@@ -4,10 +4,8 @@ namespace App\Models\Relationships;
 
 use App\Models\Collection;
 use App\Models\File;
-use App\Models\UpdateRequest;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Kalnoy\Nestedset\AncestorsRelation;
 
 trait PageRelationships
@@ -35,10 +33,5 @@ trait PageRelationships
     public function landingPageAncestors(): AncestorsRelation
     {
         return $this->ancestors()->where('page_type', static::PAGE_TYPE_LANDING);
-    }
-
-    public function updateRequests(): MorphMany
-    {
-        return $this->MorphMany(UpdateRequest::class, 'updateable');
     }
 }

--- a/app/Observers/OrganisationEventObserver.php
+++ b/app/Observers/OrganisationEventObserver.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\OrganisationEvent;
+use App\Models\UpdateRequest;
+
+class OrganisationEventObserver
+{
+    /**
+     * Handle the organisation event "deleting" event.
+     */
+    public function deleting(OrganisationEvent $event)
+    {
+        if ($event->updateRequests->isNotEmpty()) {
+            $event->updateRequests->each(function (UpdateRequest $updateRequest) {
+                $updateRequest->delete();
+            });
+        }
+    }
+}

--- a/app/Providers/ModelServiceProvider.php
+++ b/app/Providers/ModelServiceProvider.php
@@ -21,6 +21,7 @@ use App\Observers\CollectionObserver;
 use App\Observers\CollectionTaxonomyObserver;
 use App\Observers\FileObserver;
 use App\Observers\LocationObserver;
+use App\Observers\OrganisationEventObserver;
 use App\Observers\OrganisationObserver;
 use App\Observers\PageObserver;
 use App\Observers\ReferralObserver;
@@ -46,6 +47,7 @@ class ModelServiceProvider extends ServiceProvider
         Page::observe(PageObserver::class);
         Location::observe(LocationObserver::class);
         Organisation::observe(OrganisationObserver::class);
+        OrganisationEvent::observe(OrganisationEventObserver::class);
         Referral::observe(ReferralObserver::class);
         Report::observe(ReportObserver::class);
         ServiceLocation::observe(ServiceLocationObserver::class);

--- a/tests/Feature/PagesTest.php
+++ b/tests/Feature/PagesTest.php
@@ -4341,8 +4341,7 @@ class PagesTest extends TestCase
         /**
          * @var \App\Models\User $user
          */
-        $user = User::factory()->create();
-        $user->makeSuperAdmin();
+        $user = User::factory()->create()->makeGlobalAdmin();
 
         Passport::actingAs($user);
 
@@ -4368,6 +4367,8 @@ class PagesTest extends TestCase
         $updateRequest = UpdateRequest::find($response->json()['id']);
 
         $this->assertEquals($data, $updateRequest->data);
+
+        Passport::actingAs(User::factory()->create()->makeSuperAdmin());
 
         $response = $this->json('DELETE', '/core/v1/pages/' . $page->id);
 

--- a/tests/Feature/PagesTest.php
+++ b/tests/Feature/PagesTest.php
@@ -4341,7 +4341,7 @@ class PagesTest extends TestCase
         /**
          * @var \App\Models\User $user
          */
-        $user = User::factory()->create()->makeGlobalAdmin();
+        $user = User::factory()->create()->makeContentAdmin();
 
         Passport::actingAs($user);
 


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/4012/remove-outstanding-update-requests-when-entities-are-deleted

- Added tests to check that outstanding update requests for organisations, services, events, pages and locations are deleted when the entity is deleted
- Added functionality to delete outstanding update requests on deletion to pages and events

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
