### PR TITLE
Add updateable ID to update request for new entity

### DIFF
--- a/app/Http/Controllers/Core/V1/UpdateRequest/ApproveController.php
+++ b/app/Http/Controllers/Core/V1/UpdateRequest/ApproveController.php
@@ -36,11 +36,11 @@ class ApproveController extends Controller
         }
 
         return DB::transaction(function () use ($request, $updateRequest) {
-            $updateRequest->apply($request->user('api'));
+            $approvedUpdateRequest = $updateRequest->apply($request->user('api'));
 
             event(EndpointHit::onUpdate($request, "Approved update request [{$updateRequest->id}]", $updateRequest));
 
-            return new UpdateRequestResource($updateRequest);
+            return new UpdateRequestResource($approvedUpdateRequest);
         });
     }
 }

--- a/app/Models/UpdateRequest.php
+++ b/app/Models/UpdateRequest.php
@@ -60,7 +60,14 @@ class UpdateRequest extends Model
 
     public function isNew(): bool
     {
-        return $this->updateable_id === null;
+        return in_array($this->updateable_type, [
+            static::NEW_TYPE_ORGANISATION_EVENT,
+            static::NEW_TYPE_ORGANISATION_GLOBAL_ADMIN,
+            static::NEW_TYPE_ORGANISATION_SIGN_UP_FORM,
+            static::NEW_TYPE_PAGE,
+            static::NEW_TYPE_SERVICE_GLOBAL_ADMIN,
+            static::NEW_TYPE_SERVICE_ORG_ADMIN,
+        ]);
     }
 
     public function isExisting(): bool

--- a/app/Rules/PageContent.php
+++ b/app/Rules/PageContent.php
@@ -51,12 +51,12 @@ class PageContent implements ValidationRule
                 return;
             }
 
-            $validateMarkdown = new MarkdownMaxLength(config('local.page_copy_max_chars'), 'Description tab - The page content must be ' . config('local.page_copy_max_chars') . ' characters or fewer.');
-
-            $validateMarkdown->validate($attribute, $value['value'], fn ($msg) => $fail($msg));
-
             if (($this->pageType === 'landing' && mb_strpos($attribute, 'introduction') && empty($value['value']))) {
                 $fail('Page content is required for introduction');
+            } elseif (!empty($value['value'])) {
+                $validateMarkdown = new MarkdownMaxLength(config('local.page_copy_max_chars'), 'Description tab - The page content must be ' . config('local.page_copy_max_chars') . ' characters or fewer.');
+
+                $validateMarkdown->validate($attribute, $value['value'], fn ($msg) => $fail($msg));
             }
 
         } elseif ($value['type'] === 'cta') {

--- a/app/UpdateRequest/NewOrganisationCreatedByGlobalAdmin.php
+++ b/app/UpdateRequest/NewOrganisationCreatedByGlobalAdmin.php
@@ -81,6 +81,8 @@ class NewOrganisationCreatedByGlobalAdmin implements AppliesUpdateRequests
             $organisation->syncTaxonomyRelationships($taxonomies);
         }
 
+        $updateRequest->updateable_id = $organisation->id;
+
         return $updateRequest;
     }
 

--- a/app/UpdateRequest/NewOrganisationEventCreatedByOrgAdmin.php
+++ b/app/UpdateRequest/NewOrganisationEventCreatedByOrgAdmin.php
@@ -105,6 +105,8 @@ class NewOrganisationEventCreatedByOrgAdmin implements AppliesUpdateRequests
         // Ensure conditional fields are reset if needed.
         $organisationEvent->resetConditionalFields();
 
+        $updateRequest->updateable_id = $organisationEvent->id;
+
         return $updateRequest;
     }
 

--- a/app/UpdateRequest/NewPage.php
+++ b/app/UpdateRequest/NewPage.php
@@ -92,6 +92,8 @@ class NewPage implements AppliesUpdateRequests
             $page->updateCollections($data['collections']);
         }
 
+        $updateRequest->updateable_id = $page->id;
+
         return $updateRequest;
     }
 

--- a/app/UpdateRequest/NewServiceCreatedByGlobalAdmin.php
+++ b/app/UpdateRequest/NewServiceCreatedByGlobalAdmin.php
@@ -167,6 +167,8 @@ class NewServiceCreatedByGlobalAdmin implements AppliesUpdateRequests
         // Ensure conditional fields are reset if needed.
         $service->resetConditionalFields();
 
+        $updateRequest->updateable_id = $service->id;
+
         return $updateRequest;
     }
 

--- a/app/UpdateRequest/NewServiceCreatedByOrgAdmin.php
+++ b/app/UpdateRequest/NewServiceCreatedByOrgAdmin.php
@@ -149,6 +149,8 @@ class NewServiceCreatedByOrgAdmin implements AppliesUpdateRequests
         // Ensure conditional fields are reset if needed.
         $service->resetConditionalFields();
 
+        $updateRequest->updateable_id = $service->id;
+
         return $updateRequest;
     }
 

--- a/tests/Feature/UpdateRequestsTest.php
+++ b/tests/Feature/UpdateRequestsTest.php
@@ -1150,6 +1150,7 @@ class UpdateRequestsTest extends TestCase
         $response = $this->json('PUT', "/core/v1/update-requests/{$updateRequest->id}/approve");
 
         $response->assertStatus(Response::HTTP_OK);
+
         $this->assertDatabaseHas((new UpdateRequest())->getTable(), [
             'id' => $updateRequest->id,
             'actioning_user_id' => $globalAdminUser->id,


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/3307/add-new-approve-and-edit-button-to-update-requests

- Update requests for new entities should return the new entity ID once it is created

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
