### PR TITLE
Feature/sc 3347/update slug auto increment logic to apply

### DIFF
--- a/app/BatchImport/OpenActiveTaxonomyImporter.php
+++ b/app/BatchImport/OpenActiveTaxonomyImporter.php
@@ -144,7 +144,7 @@ class OpenActiveTaxonomyImporter
         ];
 
         if (Schema::hasColumn('taxonomies', 'slug')) {
-            $modelData['slug'] = $this->slugGenerator->generate($taxonomyData['prefLabel'], 'taxonomies');
+            $modelData['slug'] = $this->slugGenerator->generate($taxonomyData['prefLabel'], (new Taxonomy()));
         }
 
         return $modelData;

--- a/app/Http/Controllers/Core/V1/CollectionCategoryController.php
+++ b/app/Http/Controllers/Core/V1/CollectionCategoryController.php
@@ -73,7 +73,7 @@ class CollectionCategoryController extends Controller
             // Create the collection record.
             $category = Collection::create([
                 'type' => Collection::TYPE_CATEGORY,
-                'slug' => $slugGenerator->generate($request->name, table(Collection::class)),
+                'slug' => $slugGenerator->generate($request->name, (new Collection())),
                 'name' => $request->name,
                 'meta' => [
                     'intro' => $request->intro,
@@ -140,9 +140,7 @@ class CollectionCategoryController extends Controller
 
             // Update the collection record.
             $collection->update([
-                'slug' => $slugGenerator->compareEquals($request->name, $collection->slug)
-                ? $collection->slug
-                : $slugGenerator->generate($request->name, table(Collection::class)),
+                'slug' => $slugGenerator->generate($request->name, $collection),
                 'name' => $request->name,
                 'meta' => [
                     'intro' => $request->intro,

--- a/app/Http/Controllers/Core/V1/CollectionOrganisationEventController.php
+++ b/app/Http/Controllers/Core/V1/CollectionOrganisationEventController.php
@@ -73,7 +73,7 @@ class CollectionOrganisationEventController extends Controller
             // Create the collection record.
             $organisationEventCollection = Collection::create([
                 'type' => Collection::TYPE_ORGANISATION_EVENT,
-                'slug' => $slugGenerator->generate($request->name, table(Collection::class)),
+                'slug' => $slugGenerator->generate($request->name, (new Collection())),
                 'name' => $request->name,
                 'meta' => [
                     'intro' => $request->intro,
@@ -136,16 +136,14 @@ class CollectionOrganisationEventController extends Controller
 
             // Update the collection record.
             $collection->update([
-                'slug' => $slugGenerator->compareEquals($request->name, $collection->slug)
-                    ? $collection->slug
-                    : $slugGenerator->generate($request->name, table(Collection::class)),
+                'slug' => $slugGenerator->generate($request->name, $collection),
                 'name' => $request->name,
                 'meta' => [
                     'intro' => $request->intro,
                     'subtitle' => $request->subtitle,
                     'image_file_id' => $request->has('image_file_id')
-                        ? $request->image_file_id
-                        : $collection->meta['image_file_id'] ?? null,
+                    ? $request->image_file_id
+                    : $collection->meta['image_file_id'] ?? null,
                     'sideboxes' => $sideboxes,
                 ],
                 'order' => $request->order,

--- a/app/Http/Controllers/Core/V1/CollectionPersonaController.php
+++ b/app/Http/Controllers/Core/V1/CollectionPersonaController.php
@@ -73,7 +73,7 @@ class CollectionPersonaController extends Controller
             // Create the collection record.
             $persona = Collection::create([
                 'type' => Collection::TYPE_PERSONA,
-                'slug' => $slugGenerator->generate($request->name, table(Collection::class)),
+                'slug' => $slugGenerator->generate($request->name, (new Collection())),
                 'name' => $request->name,
                 'meta' => [
                     'intro' => $request->intro,
@@ -137,16 +137,14 @@ class CollectionPersonaController extends Controller
 
             // Update the collection record.
             $collection->update([
-                'slug' => $slugGenerator->compareEquals($request->name, $collection->slug)
-                    ? $collection->slug
-                    : $slugGenerator->generate($request->name, table(Collection::class)),
+                'slug' => $slugGenerator->generate($request->name, $collection),
                 'name' => $request->name,
                 'meta' => [
                     'intro' => $request->intro,
                     'subtitle' => $request->subtitle,
                     'image_file_id' => $request->has('image_file_id')
-                        ? $request->image_file_id
-                        : $collection->meta['image_file_id'] ?? null,
+                    ? $request->image_file_id
+                    : $collection->meta['image_file_id'] ?? null,
                     'sideboxes' => $sideboxes,
                 ],
                 'order' => $request->order,

--- a/app/Http/Controllers/Core/V1/TaxonomyCategoryController.php
+++ b/app/Http/Controllers/Core/V1/TaxonomyCategoryController.php
@@ -54,12 +54,12 @@ class TaxonomyCategoryController extends Controller
     {
         return DB::transaction(function () use ($request, $slugGenerator) {
             $parent = $request->filled('parent_id')
-                ? Taxonomy::query()->findOrFail($request->parent_id)
-                : Taxonomy::category();
+            ? Taxonomy::query()->findOrFail($request->parent_id)
+            : Taxonomy::category();
 
             $category = Taxonomy::create([
                 'parent_id' => $parent->id,
-                'slug' => $slugGenerator->generate($request->name, table(Taxonomy::class)),
+                'slug' => $slugGenerator->generate($request->name, (new Taxonomy())),
                 'name' => $request->name,
                 'order' => $request->order,
                 'depth' => 0, // Placeholder
@@ -98,14 +98,12 @@ class TaxonomyCategoryController extends Controller
     {
         return DB::transaction(function () use ($request, $slugGenerator, $taxonomy) {
             $parent = $request->filled('parent_id')
-                ? Taxonomy::query()->findOrFail($request->parent_id)
-                : Taxonomy::category();
+            ? Taxonomy::query()->findOrFail($request->parent_id)
+            : Taxonomy::category();
 
             $taxonomy->update([
                 'parent_id' => $parent->id,
-                'slug' => $slugGenerator->compareEquals($request->name, $taxonomy->slug)
-                    ? $taxonomy->slug
-                    : $slugGenerator->generate($request->name, table(Taxonomy::class)),
+                'slug' => $slugGenerator->generate($request->name, $taxonomy),
                 'name' => $request->name,
                 'order' => $request->order,
                 'depth' => 0, // Placeholder

--- a/app/Http/Controllers/Core/V1/TaxonomyOrganisationController.php
+++ b/app/Http/Controllers/Core/V1/TaxonomyOrganisationController.php
@@ -53,7 +53,7 @@ class TaxonomyOrganisationController extends Controller
     {
         return DB::transaction(function () use ($request, $slugGenerator) {
             $organisation = Taxonomy::organisation()->children()->create([
-                'slug' => $slugGenerator->generate($request->name, table(Taxonomy::class)),
+                'slug' => $slugGenerator->generate($request->name, (new Taxonomy())),
                 'name' => $request->name,
                 'order' => $request->order,
                 'depth' => 1,
@@ -90,9 +90,7 @@ class TaxonomyOrganisationController extends Controller
     {
         return DB::transaction(function () use ($request, $slugGenerator, $taxonomy) {
             $taxonomy->update([
-                'slug' => $slugGenerator->compareEquals($request->name, $taxonomy->slug)
-                    ? $taxonomy->slug
-                    : $slugGenerator->generate($request->name, table(Taxonomy::class)),
+                'slug' => $slugGenerator->generate($request->name, $taxonomy),
                 'name' => $request->name,
                 'order' => $request->order,
             ]);

--- a/app/Http/Controllers/Core/V1/TaxonomyServiceEligibilityController.php
+++ b/app/Http/Controllers/Core/V1/TaxonomyServiceEligibilityController.php
@@ -52,12 +52,12 @@ class TaxonomyServiceEligibilityController extends Controller
     {
         return DB::transaction(function () use ($request, $slugGenerator) {
             $parent = $request->filled('parent_id')
-                ? Taxonomy::query()->findOrFail($request->parent_id)
-                : Taxonomy::serviceEligibility();
+            ? Taxonomy::query()->findOrFail($request->parent_id)
+            : Taxonomy::serviceEligibility();
 
             $serviceEligibility = Taxonomy::create([
                 'parent_id' => $parent->id,
-                'slug' => $slugGenerator->generate($request->name, table(Taxonomy::class)),
+                'slug' => $slugGenerator->generate($request->name, (new Taxonomy())),
                 'name' => $request->name,
                 'order' => $request->order,
                 'depth' => 0, // Placeholder
@@ -96,14 +96,12 @@ class TaxonomyServiceEligibilityController extends Controller
     {
         return DB::transaction(function () use ($request, $slugGenerator, $taxonomy) {
             $parent = $request->filled('parent_id')
-                ? Taxonomy::query()->findOrFail($request->parent_id)
-                : Taxonomy::serviceEligibility();
+            ? Taxonomy::query()->findOrFail($request->parent_id)
+            : Taxonomy::serviceEligibility();
 
             $taxonomy->update([
                 'parent_id' => $parent->id,
-                'slug' => $slugGenerator->compareEquals($request->name, $taxonomy->slug)
-                    ? $taxonomy->slug
-                    : $slugGenerator->generate($request->name, table(Taxonomy::class)),
+                'slug' => $slugGenerator->generate($request->name, $taxonomy),
                 'name' => $request->name,
                 'order' => $request->order,
                 'depth' => 0, // Placeholder

--- a/app/Http/Requests/Organisation/StoreRequest.php
+++ b/app/Http/Requests/Organisation/StoreRequest.php
@@ -4,7 +4,6 @@ namespace App\Http\Requests\Organisation;
 
 use App\Http\Requests\HasMissingValues;
 use App\Models\File;
-use App\Models\Organisation;
 use App\Models\SocialMedia;
 use App\Models\Taxonomy;
 use App\Rules\FileIsMimeType;
@@ -44,7 +43,6 @@ class StoreRequest extends FormRequest
                 'string',
                 'min:1',
                 'max:255',
-                'unique:' . table(Organisation::class) . ',slug',
                 new Slug(),
             ],
             'name' => ['required', 'string', 'min:1', 'max:255'],

--- a/app/Http/Requests/Organisation/UpdateRequest.php
+++ b/app/Http/Requests/Organisation/UpdateRequest.php
@@ -4,7 +4,6 @@ namespace App\Http\Requests\Organisation;
 
 use App\Http\Requests\HasMissingValues;
 use App\Models\File;
-use App\Models\Organisation;
 use App\Models\SocialMedia;
 use App\Models\Taxonomy;
 use App\Rules\CanUpdateCategoryTaxonomyRelationships;
@@ -44,8 +43,6 @@ class UpdateRequest extends FormRequest
                 'string',
                 'min:1',
                 'max:255',
-                Rule::unique(table(Organisation::class), 'slug')
-                    ->ignoreModel($this->organisation),
                 new Slug(),
             ],
             'name' => ['string', 'min:1', 'max:255'],

--- a/app/Http/Requests/OrganisationEvent/StoreRequest.php
+++ b/app/Http/Requests/OrganisationEvent/StoreRequest.php
@@ -52,7 +52,7 @@ class StoreRequest extends FormRequest
                 },
             ],
             'title' => ['required', 'string', 'min:1', 'max:255'],
-            'slug' => ['required', 'string', 'min:1', 'max:255', new Slug()],
+            'slug' => ['string', 'min:1', 'max:255', new Slug()],
             'start_date' => ['required', 'date_format:Y-m-d', new DateSanity($this)],
             'end_date' => ['required', 'date_format:Y-m-d', 'after_or_equal:today', new DateSanity($this)],
             'start_time' => ['required', 'date_format:H:i:s', new DateSanity($this)],

--- a/app/Http/Requests/OrganisationEvent/StoreRequest.php
+++ b/app/Http/Requests/OrganisationEvent/StoreRequest.php
@@ -52,7 +52,7 @@ class StoreRequest extends FormRequest
                 },
             ],
             'title' => ['required', 'string', 'min:1', 'max:255'],
-            'slug' => ['string', 'min:1', 'max:255', new Slug()],
+            'slug' => ['required', 'string', 'min:1', 'max:255', new Slug()],
             'start_date' => ['required', 'date_format:Y-m-d', new DateSanity($this)],
             'end_date' => ['required', 'date_format:Y-m-d', 'after_or_equal:today', new DateSanity($this)],
             'start_time' => ['required', 'date_format:H:i:s', new DateSanity($this)],

--- a/app/Http/Requests/OrganisationEvent/UpdateRequest.php
+++ b/app/Http/Requests/OrganisationEvent/UpdateRequest.php
@@ -4,7 +4,6 @@ namespace App\Http\Requests\OrganisationEvent;
 
 use App\Http\Requests\HasMissingValues;
 use App\Models\File;
-use App\Models\OrganisationEvent;
 use App\Models\Role;
 use App\Models\Taxonomy;
 use App\Models\UserRole;
@@ -49,7 +48,6 @@ class UpdateRequest extends FormRequest
                 'string',
                 'min:1',
                 'max:255',
-                Rule::unique(table(OrganisationEvent::class), 'slug')->ignoreModel($this->organisation_event),
                 new Slug(),
                 new UserHasRole(
                     $this->user('api'),

--- a/app/Http/Requests/Page/UpdateRequest.php
+++ b/app/Http/Requests/Page/UpdateRequest.php
@@ -50,7 +50,6 @@ class UpdateRequest extends FormRequest
                 'string',
                 'min:1',
                 'max:255',
-                Rule::unique(table(Page::class), 'slug')->ignoreModel($this->page),
                 new Slug(),
                 new UserHasRole(
                     $this->user('api'),

--- a/app/Http/Requests/Service/StoreRequest.php
+++ b/app/Http/Requests/Service/StoreRequest.php
@@ -55,7 +55,7 @@ class StoreRequest extends FormRequest
                     }
                 },
             ],
-            'slug' => ['required', 'string', 'min:1', 'max:255', new Slug()],
+            'slug' => ['string', 'min:1', 'max:255', new Slug()],
             'name' => ['required', 'string', 'min:1', 'max:255'],
             'type' => [
                 'required',

--- a/app/Http/Requests/Service/UpdateRequest.php
+++ b/app/Http/Requests/Service/UpdateRequest.php
@@ -63,7 +63,6 @@ class UpdateRequest extends FormRequest
                 'string',
                 'min:1',
                 'max:255',
-                Rule::unique(table(Service::class), 'slug')->ignoreModel($this->service),
                 new Slug(),
                 new UserHasRole(
                     $this->user('api'),

--- a/app/Models/Organisation.php
+++ b/app/Models/Organisation.php
@@ -8,6 +8,7 @@ use App\Models\Mutators\OrganisationMutators;
 use App\Models\Relationships\OrganisationRelationships;
 use App\Models\Scopes\OrganisationScopes;
 use App\Rules\FileIsMimeType;
+use App\Services\DataPersistence\HasUniqueSlug;
 use App\TaxonomyRelationships\HasTaxonomyRelationships;
 use App\TaxonomyRelationships\UpdateTaxonomyRelationships;
 use App\UpdateRequest\UpdateRequests;
@@ -27,6 +28,7 @@ class Organisation extends Model implements AppliesUpdateRequests, HasTaxonomyRe
     use OrganisationScopes;
     use UpdateRequests;
     use UpdateTaxonomyRelationships;
+    use HasUniqueSlug;
 
     /**
      * Return the OrganisationTaxonomy relationship.
@@ -66,7 +68,7 @@ class Organisation extends Model implements AppliesUpdateRequests, HasTaxonomyRe
         $data = $updateRequest->data;
 
         $this->update([
-            'slug' => Arr::get($data, 'slug', $this->slug),
+            'slug' => $this->uniqueSlug(Arr::get($data, 'slug', $this->slug), $this),
             'name' => Arr::get($data, 'name', $this->name),
             'description' => sanitize_markdown(Arr::get($data, 'description', $this->description)),
             'url' => Arr::get($data, 'url', $this->url),

--- a/app/Models/OrganisationEvent.php
+++ b/app/Models/OrganisationEvent.php
@@ -3,7 +3,6 @@
 namespace App\Models;
 
 use App\Contracts\AppliesUpdateRequests;
-use App\Generators\UniqueSlugGenerator;
 use App\Http\Requests\OrganisationEvent\UpdateRequest as UpdateOrganisationEventRequest;
 use App\Models\Mutators\OrganisationEventMutators;
 use App\Models\Relationships\OrganisationEventRelationships;
@@ -117,12 +116,7 @@ class OrganisationEvent extends Model implements AppliesUpdateRequests, HasTaxon
      */
     public function applyUpdateRequest(UpdateRequest $updateRequest): UpdateRequest
     {
-        $slugGenerator = app(UniqueSlugGenerator::class);
         $data = $updateRequest->data;
-        $slug = Arr::get($data, 'slug', $this->slug);
-        if ($slug !== $this->slug) {
-            $slug = $slugGenerator->generate($slug, 'pages');
-        }
 
         // Update the Image File entity if new
         if (Arr::get($data, 'image_file_id', $this->image_file_id) !== $this->image_file_id && !empty($data['image_file_id'])) {
@@ -139,7 +133,7 @@ class OrganisationEvent extends Model implements AppliesUpdateRequests, HasTaxon
         $this->update([
             'organisation_id' => $this->organisation_id,
             'title' => Arr::get($data, 'title', $this->title),
-            'slug' => $slug,
+            'slug' => Arr::get($data, 'slug', $this->slug),
             'intro' => Arr::get($data, 'intro', $this->intro),
             'description' => sanitize_markdown(
                 Arr::get($data, 'description', $this->description)

--- a/app/Models/OrganisationEvent.php
+++ b/app/Models/OrganisationEvent.php
@@ -8,6 +8,7 @@ use App\Models\Mutators\OrganisationEventMutators;
 use App\Models\Relationships\OrganisationEventRelationships;
 use App\Models\Scopes\OrganisationEventScopes;
 use App\Rules\FileIsMimeType;
+use App\Services\DataPersistence\HasUniqueSlug;
 use App\TaxonomyRelationships\HasTaxonomyRelationships;
 use App\TaxonomyRelationships\UpdateTaxonomyRelationships;
 use App\UpdateRequest\UpdateRequests;
@@ -28,6 +29,7 @@ class OrganisationEvent extends Model implements AppliesUpdateRequests, HasTaxon
     use UpdateRequests;
     use UpdateTaxonomyRelationships;
     use Searchable;
+    use HasUniqueSlug;
 
     /**
      * The attributes that should be cast to native types.
@@ -133,7 +135,7 @@ class OrganisationEvent extends Model implements AppliesUpdateRequests, HasTaxon
         $this->update([
             'organisation_id' => $this->organisation_id,
             'title' => Arr::get($data, 'title', $this->title),
-            'slug' => Arr::get($data, 'slug', $this->slug),
+            'slug' => $this->uniqueSlug(Arr::get($data, 'slug', $this->slug), $this),
             'intro' => Arr::get($data, 'intro', $this->intro),
             'description' => sanitize_markdown(
                 Arr::get($data, 'description', $this->description)

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -3,12 +3,12 @@
 namespace App\Models;
 
 use App\Contracts\AppliesUpdateRequests;
-use App\Generators\UniqueSlugGenerator;
 use App\Http\Requests\Page\UpdateRequest as UpdatePageRequest;
 use App\Models\Mutators\PageMutators;
 use App\Models\Relationships\PageRelationships;
 use App\Models\Scopes\PageScopes;
 use App\Rules\FileIsMimeType;
+use App\Services\DataPersistence\HasUniqueSlug;
 use App\UpdateRequest\UpdateRequests;
 use ElasticScoutDriverPlus\Searchable;
 use Illuminate\Contracts\Validation\Validator;
@@ -25,6 +25,7 @@ class Page extends Model implements AppliesUpdateRequests
     use PageScopes;
     use NodeTrait;
     use UpdateRequests;
+    use HasUniqueSlug;
 
     /**
      * NodeTrait::usesSoftDelete and Laravel\Scout\Searchable::usesSoftDelete clash.
@@ -282,17 +283,12 @@ class Page extends Model implements AppliesUpdateRequests
      */
     public function applyUpdateRequest(UpdateRequest $updateRequest): UpdateRequest
     {
-        $slugGenerator = app(UniqueSlugGenerator::class);
         $data = $updateRequest->data;
-        $slug = Arr::get($data, 'slug', $this->slug);
-        if ($slug !== $this->slug) {
-            $slug = $slugGenerator->generate($slug, 'pages');
-        }
 
         // Update the page record.
         $this->update([
             'title' => Arr::get($data, 'title', $this->title),
-            'slug' => $slug,
+            'slug' => Arr::has($data, 'slug') ? $this->uniqueSlug(Arr::get($data, 'slug'), $this) : $this->slug,
             'excerpt' => Arr::get($data, 'excerpt', $this->excerpt),
             'content' => Arr::get($data, 'content', $this->content),
             'page_type' => Arr::get($data, 'page_type', $this->page_type),

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -12,6 +12,7 @@ use App\Models\Scopes\ServiceScopes;
 use App\Notifications\Notifiable;
 use App\Notifications\Notifications;
 use App\Rules\FileIsMimeType;
+use App\Services\DataPersistence\HasUniqueSlug;
 use App\Sms\Sms;
 use App\TaxonomyRelationships\HasTaxonomyRelationships;
 use App\TaxonomyRelationships\UpdateServiceEligibilityTaxonomyRelationships;
@@ -33,6 +34,7 @@ use Illuminate\Support\Str;
 class Service extends Model implements AppliesUpdateRequests, Notifiable, HasTaxonomyRelationships
 {
     use HasFactory;
+    use HasUniqueSlug;
     use DispatchesJobs;
     use Notifications;
     use Searchable;
@@ -196,7 +198,7 @@ class Service extends Model implements AppliesUpdateRequests, Notifiable, HasTax
         // Update the service record.
         $this->update([
             'organisation_id' => Arr::get($data, 'organisation_id', $this->organisation_id),
-            'slug' => Arr::get($data, 'slug', $this->slug),
+            'slug' => $this->uniqueSlug(Arr::get($data, 'slug', $this->slug), $this),
             'name' => Arr::get($data, 'name', $this->name),
             'type' => Arr::get($data, 'type', $this->type),
             'status' => Arr::get($data, 'status', $this->status),

--- a/app/Services/DataPersistence/HasUniqueSlug.php
+++ b/app/Services/DataPersistence/HasUniqueSlug.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Services\DataPersistence;
+
+use App\Generators\UniqueSlugGenerator;
+use App\Models\Model;
+use Illuminate\Contracts\Container\BindingResolutionException;
+
+trait HasUniqueSlug
+{
+    /**
+     * Return a unique version of the proposed slug.
+     *
+     * @param string $slug
+     * @param App\Models\Model $table
+     * @param string $column
+     * @param int $index
+     * @throws BindingResolutionException
+     * @return string
+     */
+    public function uniqueSlug(string $slug, Model $model, string $column = 'slug', int $index = 0): string
+    {
+        $slugGenerator = app(UniqueSlugGenerator::class);
+
+        return $slugGenerator->generate($slug, $model, $column, $index);
+    }
+}

--- a/app/Services/DataPersistence/OrganisationEventPersistenceService.php
+++ b/app/Services/DataPersistence/OrganisationEventPersistenceService.php
@@ -8,7 +8,6 @@ use App\Models\Model;
 use App\Models\OrganisationEvent;
 use App\Models\Taxonomy;
 use App\Models\UpdateRequest as UpdateRequestModel;
-use App\Support\MissingValue;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\DB;
 
@@ -107,7 +106,7 @@ class OrganisationEventPersistenceService implements DataPersistenceService
         return DB::transaction(function () use ($request, $event) {
             $data = array_filter_missing([
                 'title' => $request->missingValue('title'),
-                'slug' => $request->has('slug') ? $this->uniqueSlug($request->slug, $event ?? (new OrganisationEvent())) : new MissingValue(),
+                'slug' => $request->missingValue('slug'),
                 'start_date' => $request->missingValue('start_date'),
                 'end_date' => $request->missingValue('end_date'),
                 'start_time' => $request->missingValue('start_time'),

--- a/app/Services/DataPersistence/OrganisationPersistenceService.php
+++ b/app/Services/DataPersistence/OrganisationPersistenceService.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Facades\DB;
 class OrganisationPersistenceService implements DataPersistenceService
 {
     use ResizesImages;
+    use HasUniqueSlug;
 
     /**
      * Store the model.
@@ -42,7 +43,7 @@ class OrganisationPersistenceService implements DataPersistenceService
         return DB::transaction(function () use ($request) {
             // Create the Organisation.
             $organisation = Organisation::create([
-                'slug' => $request->slug,
+                'slug' => $this->uniqueSlug($request->input('slug', $request->input('name')), (new Organisation())),
                 'name' => $request->name,
                 'description' => sanitize_markdown($request->description),
                 'url' => $request->url,

--- a/app/Services/DataPersistence/PagePersistenceService.php
+++ b/app/Services/DataPersistence/PagePersistenceService.php
@@ -3,28 +3,17 @@
 namespace App\Services\DataPersistence;
 
 use App\Contracts\DataPersistenceService;
-use App\Generators\UniqueSlugGenerator;
 use App\Models\Model;
 use App\Models\Page;
 use App\Models\UpdateRequest as UpdateRequestModel;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 
 class PagePersistenceService implements DataPersistenceService
 {
     use ResizesImages;
-
-    /**
-     * Unique Slug Generator.
-     *
-     * @var \App\Generators\UniqueSlugGenerator
-     */
-    protected $slugGenerator;
-
-    public function __construct(UniqueSlugGenerator $slugGenerator)
-    {
-        $this->slugGenerator = $slugGenerator;
-    }
+    use HasUniqueSlug;
 
     /**
      * Store the model.
@@ -58,7 +47,7 @@ class PagePersistenceService implements DataPersistenceService
             $page = Page::make(
                 [
                     'title' => $request->input('title'),
-                    'slug' => $this->slugGenerator->generate($request->input('slug', $request->input('title')), 'pages'),
+                    'slug' => $request->input('slug', Str::slug($request->input('title'))),
                     'excerpt' => $request->input('excerpt'),
                     'content' => $request->input('content', []),
                     'page_type' => $request->input('page_type', Page::PAGE_TYPE_INFORMATION),

--- a/app/Services/DataPersistence/ServicePersistenceService.php
+++ b/app/Services/DataPersistence/ServicePersistenceService.php
@@ -36,8 +36,8 @@ class ServicePersistenceService implements DataPersistenceService
      * Create an update request to update or create a Service using the data from the request.
      *
      * @param Illuminate\Foundation\Http\FormRequest $request
-     * @param App\Models\Service $service
-     * @return App\Models\UpdateRequest
+     * @param \App\Models\Service $service
+     * @return \App\Models\UpdateRequest
      */
     private function processAsUpdateRequest(FormRequest $request, ?Service $service = null): UpdateRequestModel
     {

--- a/app/Services/DataPersistence/ServicePersistenceService.php
+++ b/app/Services/DataPersistence/ServicePersistenceService.php
@@ -45,7 +45,7 @@ class ServicePersistenceService implements DataPersistenceService
             // Initialise the data array
             $data = array_filter_missing([
                 'organisation_id' => $request->missingValue('organisation_id'),
-                'slug' => $request->has('slug') ? $this->uniqueSlug($request->slug, $service ?? (new Service())) : new MissingValue(),
+                'slug' => $request->missingValue('slug'),
                 'name' => $request->missingValue('name'),
                 'type' => $request->missingValue('type'),
                 'status' => $request->missingValue('status'),
@@ -267,22 +267,4 @@ class ServicePersistenceService implements DataPersistenceService
             return $service;
         });
     }
-
-    /**
-     * Return a unique version of the proposed slug.
-     */
-    // public function uniqueSlug(string $slug): string
-    // {
-    //     $uniqueSlug = $baseSlug = preg_replace('|\-\d$|', '', $slug);
-    //     $suffix = 1;
-    //     do {
-    //         $exists = DB::table((new Service())->getTable())->where('slug', $uniqueSlug)->exists();
-    //         if ($exists) {
-    //             $uniqueSlug = $baseSlug . '-' . $suffix;
-    //         }
-    //         $suffix++;
-    //     } while ($exists);
-
-    //     return $uniqueSlug;
-    // }
 }

--- a/app/Services/DataPersistence/ServicePersistenceService.php
+++ b/app/Services/DataPersistence/ServicePersistenceService.php
@@ -18,6 +18,7 @@ use Illuminate\Support\Str;
 class ServicePersistenceService implements DataPersistenceService
 {
     use ResizesImages;
+    use HasUniqueSlug;
 
     public function store(FormRequest $request)
     {
@@ -31,13 +32,20 @@ class ServicePersistenceService implements DataPersistenceService
         return $this->processAsUpdateRequest($request, $model);
     }
 
-    private function processAsUpdateRequest(FormRequest $request, $service = null)
+    /**
+     * Create an update request to update or create a Service using the data from the request.
+     *
+     * @param Illuminate\Foundation\Http\FormRequest $request
+     * @param App\Models\Service $service
+     * @return App\Models\UpdateRequest
+     */
+    private function processAsUpdateRequest(FormRequest $request, ?Service $service = null): UpdateRequestModel
     {
         return DB::transaction(function () use ($request, $service) {
             // Initialise the data array
             $data = array_filter_missing([
                 'organisation_id' => $request->missingValue('organisation_id'),
-                'slug' => $request->missingValue('slug'),
+                'slug' => $request->has('slug') ? $this->uniqueSlug($request->slug, $service ?? (new Service())) : new MissingValue(),
                 'name' => $request->missingValue('name'),
                 'type' => $request->missingValue('type'),
                 'status' => $request->missingValue('status'),
@@ -139,12 +147,18 @@ class ServicePersistenceService implements DataPersistenceService
         });
     }
 
-    private function processAsNewEntity(FormRequest $request)
+    /**
+     * Create a new service using the data from the request.
+     *
+     * @param Illuminate\Foundation\Http\FormRequest $request
+     * @return App\Models\Service
+     */
+    private function processAsNewEntity(FormRequest $request): Service
     {
         return DB::transaction(function () use ($request) {
             $initialCreateData = [
                 'organisation_id' => $request->organisation_id,
-                'slug' => $this->uniqueSlug($request->slug),
+                'slug' => $this->uniqueSlug($request->input('slug', $request->input('title')), (new Service())),
                 'name' => $request->name,
                 'type' => $request->type,
                 'status' => $request->status,
@@ -257,18 +271,18 @@ class ServicePersistenceService implements DataPersistenceService
     /**
      * Return a unique version of the proposed slug.
      */
-    public function uniqueSlug(string $slug): string
-    {
-        $uniqueSlug = $baseSlug = preg_replace('|\-\d$|', '', $slug);
-        $suffix = 1;
-        do {
-            $exists = DB::table((new Service())->getTable())->where('slug', $uniqueSlug)->exists();
-            if ($exists) {
-                $uniqueSlug = $baseSlug . '-' . $suffix;
-            }
-            $suffix++;
-        } while ($exists);
+    // public function uniqueSlug(string $slug): string
+    // {
+    //     $uniqueSlug = $baseSlug = preg_replace('|\-\d$|', '', $slug);
+    //     $suffix = 1;
+    //     do {
+    //         $exists = DB::table((new Service())->getTable())->where('slug', $uniqueSlug)->exists();
+    //         if ($exists) {
+    //             $uniqueSlug = $baseSlug . '-' . $suffix;
+    //         }
+    //         $suffix++;
+    //     } while ($exists);
 
-        return $uniqueSlug;
-    }
+    //     return $uniqueSlug;
+    // }
 }

--- a/app/UpdateRequest/NewOrganisationCreatedByGlobalAdmin.php
+++ b/app/UpdateRequest/NewOrganisationCreatedByGlobalAdmin.php
@@ -9,6 +9,7 @@ use App\Models\Organisation;
 use App\Models\Taxonomy;
 use App\Models\UpdateRequest;
 use App\Rules\FileIsMimeType;
+use App\Services\DataPersistence\HasUniqueSlug;
 use App\Services\DataPersistence\ResizesImages;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Support\Arr;
@@ -18,6 +19,7 @@ use Illuminate\Support\Facades\Validator as ValidatorFacade;
 class NewOrganisationCreatedByGlobalAdmin implements AppliesUpdateRequests
 {
     use ResizesImages;
+    use HasUniqueSlug;
 
     /**
      * Check if the update request is valid.
@@ -50,7 +52,7 @@ class NewOrganisationCreatedByGlobalAdmin implements AppliesUpdateRequests
         $data = collect($updateRequest->data);
 
         $organisation = Organisation::create([
-            'slug' => $data->get('slug'),
+            'slug' => $this->uniqueSlug($data->get('slug', $data->get('name')), (new Organisation())),
             'name' => $data->get('name'),
             'description' => sanitize_markdown(
                 $data->get('description')

--- a/app/UpdateRequest/NewOrganisationEventCreatedByOrgAdmin.php
+++ b/app/UpdateRequest/NewOrganisationEventCreatedByOrgAdmin.php
@@ -3,7 +3,6 @@
 namespace App\UpdateRequest;
 
 use App\Contracts\AppliesUpdateRequests;
-use App\Generators\UniqueSlugGenerator;
 use App\Http\Requests\OrganisationEvent\StoreRequest;
 use App\Models\File;
 use App\Models\OrganisationEvent;
@@ -16,18 +15,6 @@ use Illuminate\Support\Facades\Validator as ValidatorFacade;
 
 class NewOrganisationEventCreatedByOrgAdmin implements AppliesUpdateRequests
 {
-    /**
-     * Unique Slug Generator.
-     *
-     * @var \App\Generators\UniqueSlugGenerator
-     */
-    protected $slugGenerator;
-
-    public function __construct(UniqueSlugGenerator $slugGenerator)
-    {
-        $this->slugGenerator = $slugGenerator;
-    }
-
     /**
      * Check if the update request is valid.
      */
@@ -59,7 +46,7 @@ class NewOrganisationEventCreatedByOrgAdmin implements AppliesUpdateRequests
 
         $organisationEvent = OrganisationEvent::create([
             'title' => $data->get('title'),
-            'slug' => $this->slugGenerator->generate($data->get('slug', $data->get('title')), table(OrganisationEvent::class)),
+            'slug' => $data->get('slug'),
             'start_date' => $data->get('start_date'),
             'end_date' => $data->get('end_date'),
             'start_time' => $data->get('start_time'),

--- a/app/UpdateRequest/NewOrganisationEventCreatedByOrgAdmin.php
+++ b/app/UpdateRequest/NewOrganisationEventCreatedByOrgAdmin.php
@@ -9,12 +9,15 @@ use App\Models\OrganisationEvent;
 use App\Models\Taxonomy;
 use App\Models\UpdateRequest;
 use App\Rules\FileIsMimeType;
+use App\Services\DataPersistence\HasUniqueSlug;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator as ValidatorFacade;
 
 class NewOrganisationEventCreatedByOrgAdmin implements AppliesUpdateRequests
 {
+    use HasUniqueSlug;
+
     /**
      * Check if the update request is valid.
      */
@@ -46,7 +49,7 @@ class NewOrganisationEventCreatedByOrgAdmin implements AppliesUpdateRequests
 
         $organisationEvent = OrganisationEvent::create([
             'title' => $data->get('title'),
-            'slug' => $data->get('slug'),
+            'slug' => $this->uniqueSlug($data->get('slug', $data->get('title')), (new OrganisationEvent())),
             'start_date' => $data->get('start_date'),
             'end_date' => $data->get('end_date'),
             'start_time' => $data->get('start_time'),

--- a/app/UpdateRequest/NewPage.php
+++ b/app/UpdateRequest/NewPage.php
@@ -3,28 +3,18 @@
 namespace App\UpdateRequest;
 
 use App\Contracts\AppliesUpdateRequests;
-use App\Generators\UniqueSlugGenerator;
 use App\Http\Requests\Page\StoreRequest;
 use App\Models\File;
 use App\Models\Page;
 use App\Models\UpdateRequest;
 use App\Rules\FileIsMimeType;
+use App\Services\DataPersistence\HasUniqueSlug;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Support\Facades\Validator as ValidatorFacade;
 
 class NewPage implements AppliesUpdateRequests
 {
-    /**
-     * Unique Slug Generator.
-     *
-     * @var \App\Generators\UniqueSlugGenerator
-     */
-    protected $slugGenerator;
-
-    public function __construct(UniqueSlugGenerator $slugGenerator)
-    {
-        $this->slugGenerator = $slugGenerator;
-    }
+    use HasUniqueSlug;
 
     /**
      * Check if the update request is valid.
@@ -58,7 +48,7 @@ class NewPage implements AppliesUpdateRequests
 
         $page = Page::make([
             'title' => $data->get('title'),
-            'slug' => $this->slugGenerator->generate($data->get('slug', $data->get('title')), table(Page::class)),
+            'slug' => $this->uniqueSlug($data->get('slug', $data->get('title')), (new Page())),
             'excerpt' => $data->get('excerpt'),
             'page_type' => $data->get('page_type', Page::PAGE_TYPE_INFORMATION),
             'content' => $data->get('content', []),

--- a/app/UpdateRequest/NewServiceCreatedByGlobalAdmin.php
+++ b/app/UpdateRequest/NewServiceCreatedByGlobalAdmin.php
@@ -9,6 +9,7 @@ use App\Models\Service;
 use App\Models\Tag;
 use App\Models\Taxonomy;
 use App\Models\UpdateRequest;
+use App\Services\DataPersistence\HasUniqueSlug;
 use Carbon\Carbon;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Support\Arr;
@@ -17,6 +18,8 @@ use Illuminate\Support\Str;
 
 class NewServiceCreatedByGlobalAdmin implements AppliesUpdateRequests
 {
+    use HasUniqueSlug;
+
     /**
      * Check if the update request is valid.
      */
@@ -41,7 +44,7 @@ class NewServiceCreatedByGlobalAdmin implements AppliesUpdateRequests
 
         $insert = [
             'organisation_id' => $data->get('organisation_id'),
-            'slug' => $data->get('slug'),
+            'slug' => $this->uniqueSlug($data->get('slug', $data->get('name')), (new Service())),
             'name' => $data->get('name'),
             'type' => $data->get('type'),
             'status' => $data->get('status'),

--- a/app/UpdateRequest/NewServiceCreatedByOrgAdmin.php
+++ b/app/UpdateRequest/NewServiceCreatedByOrgAdmin.php
@@ -8,6 +8,7 @@ use App\Models\File;
 use App\Models\Service;
 use App\Models\Taxonomy;
 use App\Models\UpdateRequest;
+use App\Services\DataPersistence\HasUniqueSlug;
 use Carbon\Carbon;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Support\Arr;
@@ -16,6 +17,8 @@ use Illuminate\Support\Facades\Validator as ValidatorFacade;
 
 class NewServiceCreatedByOrgAdmin implements AppliesUpdateRequests
 {
+    use HasUniqueSlug;
+
     /**
      * Check if the update request is valid.
      */
@@ -41,7 +44,7 @@ class NewServiceCreatedByOrgAdmin implements AppliesUpdateRequests
 
         $insert = [
             'organisation_id' => $data->get('organisation_id'),
-            'slug' => $data->get('slug'),
+            'slug' => $this->uniqueSlug($data->get('slug', $data->get('name')), (new Service())),
             'name' => $data->get('name'),
             'type' => $data->get('type'),
             'status' => $data->get('status'),

--- a/tests/Feature/OrganisationEventsTest.php
+++ b/tests/Feature/OrganisationEventsTest.php
@@ -675,6 +675,7 @@ class OrganisationEventsTest extends TestCase
         $date = $this->faker->dateTimeBetween('tomorrow', '+6 weeks')->format('Y-m-d');
         $payload = [
             'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $date,
             'end_date' => $date,
             'start_time' => '09:00:00',
@@ -737,6 +738,7 @@ class OrganisationEventsTest extends TestCase
         $date = $this->faker->dateTimeBetween('tomorrow', '+6 weeks')->format('Y-m-d');
         $payload = [
             'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $date,
             'end_date' => $date,
             'start_time' => '09:00:00',
@@ -796,8 +798,8 @@ class OrganisationEventsTest extends TestCase
 
         $date = $this->faker->dateTimeBetween('tomorrow', '+6 weeks')->format('Y-m-d');
         $payload = [
-            'title' =>
-            'A New Organisation Event',
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $date,
             'end_date' => $date,
             'start_time' => '09:00:00',
@@ -851,7 +853,8 @@ class OrganisationEventsTest extends TestCase
 
         $date = $this->faker->dateTimeBetween('tomorrow', '+6 weeks')->format('Y-m-d');
         $payload = [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $date,
             'end_date' => $date,
             'start_time' => '09:00:00',
@@ -894,7 +897,8 @@ class OrganisationEventsTest extends TestCase
 
         $date = $this->faker->dateTimeBetween('tomorrow', '+6 weeks')->format('Y-m-d');
         $payload = [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $date,
             'end_date' => $date,
             'start_time' => '09:00:00',
@@ -937,7 +941,8 @@ class OrganisationEventsTest extends TestCase
 
         $date = $this->faker->dateTimeBetween('tomorrow', '+6 weeks')->format('Y-m-d');
         $payload = [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $date,
             'end_date' => $date,
             'start_time' => '09:00:00',
@@ -992,7 +997,8 @@ class OrganisationEventsTest extends TestCase
 
         $date = $this->faker->dateTimeBetween('tomorrow', '+6 weeks')->format('Y-m-d');
         $payload = [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $date,
             'end_date' => $date,
             'start_time' => '09:00:00',
@@ -1041,7 +1047,8 @@ class OrganisationEventsTest extends TestCase
 
         $date = $this->faker->dateTimeBetween('tomorrow', '+6 weeks')->format('Y-m-d');
         $payload = [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $date,
             'end_date' => $date,
             'start_time' => '09:00:00',
@@ -1085,7 +1092,8 @@ class OrganisationEventsTest extends TestCase
 
         $date = $this->faker->dateTimeBetween('tomorrow', '+6 weeks')->format('Y-m-d');
         $payload = [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $date,
             'end_date' => $date,
             'start_time' => '09:00:00',
@@ -1176,7 +1184,8 @@ class OrganisationEventsTest extends TestCase
 
         $date = $this->faker->dateTimeBetween('tomorrow', '+6 weeks')->format('Y-m-d');
         $payload = [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $date,
             'end_date' => $date,
             'start_time' => '09:00:00',
@@ -1251,7 +1260,8 @@ class OrganisationEventsTest extends TestCase
 
         $date = $this->faker->dateTimeBetween('tomorrow', '+6 weeks')->format('Y-m-d');
         $payload = [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $date,
             'end_date' => $date,
             'start_time' => '09:00:00',
@@ -1309,7 +1319,8 @@ class OrganisationEventsTest extends TestCase
 
         $date = $this->faker->dateTimeBetween('tomorrow', '+6 weeks')->format('Y-m-d');
         $payload = [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $date,
             'end_date' => $date,
             'start_time' => '09:00:00',
@@ -1379,7 +1390,8 @@ class OrganisationEventsTest extends TestCase
 
         $date = $this->faker->dateTimeBetween('tomorrow', '+6 weeks')->format('Y-m-d');
         $payload = [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $date,
             'end_date' => $date,
             'start_time' => '09:00:00',
@@ -1468,7 +1480,8 @@ class OrganisationEventsTest extends TestCase
 
         $date = $this->faker->dateTimeBetween('tomorrow', '+6 weeks')->format('Y-m-d');
         $payload = [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $date,
             'end_date' => $date,
             'start_time' => '09:00:00',
@@ -1516,20 +1529,29 @@ class OrganisationEventsTest extends TestCase
         $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
         $response = $this->json('POST', '/core/v1/organisation-events', [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
         ]);
 
         $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
         $response = $this->json('POST', '/core/v1/organisation-events', [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
+        ]);
+
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+
+        $response = $this->json('POST', '/core/v1/organisation-events', [
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $date,
         ]);
 
         $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
         $response = $this->json('POST', '/core/v1/organisation-events', [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $date,
             'end_date' => $date,
         ]);
@@ -1537,7 +1559,8 @@ class OrganisationEventsTest extends TestCase
         $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
         $response = $this->json('POST', '/core/v1/organisation-events', [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $date,
             'end_date' => $date,
             'start_time' => '09:00:00',
@@ -1546,7 +1569,8 @@ class OrganisationEventsTest extends TestCase
         $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
         $response = $this->json('POST', '/core/v1/organisation-events', [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $date,
             'end_date' => $date,
             'start_time' => '09:00:00',
@@ -1556,7 +1580,8 @@ class OrganisationEventsTest extends TestCase
         $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
         $response = $this->json('POST', '/core/v1/organisation-events', [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $date,
             'end_date' => $date,
             'start_time' => '09:00:00',
@@ -1567,7 +1592,8 @@ class OrganisationEventsTest extends TestCase
         $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
         $response = $this->json('POST', '/core/v1/organisation-events', [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $date,
             'end_date' => $date,
             'start_time' => '09:00:00',
@@ -1577,6 +1603,56 @@ class OrganisationEventsTest extends TestCase
         ]);
 
         $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    /**
+     * @test
+     */
+    public function postCreateOrganisationEventCreatesUniqueSlugAsOrganisationAdmin200(): void
+    {
+        $organisation = Organisation::factory()->create();
+        $organisationEvent = OrganisationEvent::factory()->create([
+            'slug' => 'a-new-organisation-event',
+        ]);
+        $user = User::factory()->create()->makeOrganisationAdmin($organisation);
+
+        Passport::actingAs($user);
+
+        $date = $this->faker->dateTimeBetween('tomorrow', '+6 weeks')->format('Y-m-d');
+        $payload = [
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
+            'start_date' => $date,
+            'end_date' => $date,
+            'start_time' => '09:00:00',
+            'end_time' => '13:00:00',
+            'intro' => $this->faker->sentence(),
+            'description' => $this->faker->paragraph(),
+            'is_free' => true,
+            'fees_text' => null,
+            'fees_url' => null,
+            'organiser_name' => null,
+            'organiser_phone' => null,
+            'organiser_email' => null,
+            'organiser_url' => null,
+            'booking_title' => null,
+            'booking_summary' => null,
+            'booking_url' => null,
+            'booking_cta' => null,
+            'homepage' => false,
+            'is_virtual' => true,
+            'location_id' => null,
+            'organisation_id' => $organisation->id,
+            'category_taxonomies' => [],
+        ];
+
+        $response = $this->json('POST', '/core/v1/organisation-events', $payload);
+
+        $response->assertStatus(Response::HTTP_OK);
+
+        $updateRequest = UpdateRequest::find($response->json('id'));
+
+        $this->assertEquals('a-new-organisation-event-1', $updateRequest->data['slug']);
     }
 
     /**
@@ -1592,7 +1668,8 @@ class OrganisationEventsTest extends TestCase
 
         $date = $this->faker->dateTimeBetween('tomorrow', '+6 weeks')->format('Y-m-d');
         $payload = [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $date,
             'end_date' => $date,
             'start_time' => '09:00:00',
@@ -1653,7 +1730,8 @@ class OrganisationEventsTest extends TestCase
 
         $date = $this->faker->dateTimeBetween('tomorrow', '+6 weeks')->format('Y-m-d');
         $payload = [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $date,
             'end_date' => $date,
             'start_time' => '09:00:00',
@@ -1722,7 +1800,8 @@ class OrganisationEventsTest extends TestCase
 
         $date = $this->faker->dateTimeBetween('tomorrow', '+6 weeks')->format('Y-m-d');
         $payload = [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $date,
             'end_date' => $date,
             'start_time' => '09:00:00',
@@ -1791,7 +1870,8 @@ class OrganisationEventsTest extends TestCase
         $end = $this->faker->dateTimeBetween('+1 days', '+7 days')->format('Y-m-d');
 
         $payload = [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $start,
             'end_date' => $end,
             'start_time' => '09:00:00',
@@ -1836,7 +1916,8 @@ class OrganisationEventsTest extends TestCase
         $end = $this->faker->dateTimeBetween('-3 days', '-1 days')->format('Y-m-d');
 
         $payload = [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $start,
             'end_date' => $end,
             'start_time' => '09:00:00',
@@ -1881,7 +1962,8 @@ class OrganisationEventsTest extends TestCase
         $end = $this->faker->dateTimeBetween('+1 days', '+3 days')->format('Y-m-d');
 
         $payload = [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $start,
             'end_date' => $end,
             'start_time' => '09:00:00',
@@ -1926,7 +2008,8 @@ class OrganisationEventsTest extends TestCase
         $end = Carbon::now()->addDay()->format('Y-m-d');
 
         $payload = [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $start,
             'end_date' => $end,
             'start_time' => '09:00:00',
@@ -2263,7 +2346,8 @@ class OrganisationEventsTest extends TestCase
 
         $date = $this->faker->dateTimeBetween('tomorrow', '+6 weeks')->format('Y-m-d');
         $payload = [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $date,
             'end_date' => $date,
             'start_time' => '09:00:00',
@@ -2312,7 +2396,8 @@ class OrganisationEventsTest extends TestCase
 
         $date = $this->faker->dateTimeBetween('tomorrow', '+6 weeks')->format('Y-m-d');
         $payload = [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $date,
             'end_date' => $date,
             'start_time' => '09:00:00',
@@ -2367,7 +2452,8 @@ class OrganisationEventsTest extends TestCase
 
         $date = $this->faker->dateTimeBetween('tomorrow', '+6 weeks')->format('Y-m-d');
         $payload = [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $date,
             'end_date' => $date,
             'start_time' => '09:00:00',
@@ -2426,7 +2512,8 @@ class OrganisationEventsTest extends TestCase
 
         $date = $this->faker->dateTimeBetween('tomorrow', '+6 weeks')->format('Y-m-d');
         $payload = [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $date,
             'end_date' => $date,
             'start_time' => '09:00:00',
@@ -2548,7 +2635,8 @@ class OrganisationEventsTest extends TestCase
 
         $date = $this->faker->dateTimeBetween('tomorrow', '+6 weeks')->format('Y-m-d');
         $payload = [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $date,
             'end_date' => $date,
             'start_time' => '09:00:00',
@@ -2594,7 +2682,8 @@ class OrganisationEventsTest extends TestCase
 
         $date = $this->faker->dateTimeBetween('tomorrow', '+6 weeks')->format('Y-m-d');
         $payload = [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $date,
             'end_date' => $date,
             'start_time' => '09:00:00',
@@ -2687,46 +2776,50 @@ class OrganisationEventsTest extends TestCase
 
         Passport::actingAs($user);
 
-        $organisationEvent = OrganisationEvent::factory()->create([
+        $organisationEvent1 = OrganisationEvent::factory()->create([
             'organisation_id' => $organisation->id,
+            'slug' => 'event-slug',
         ]);
 
-        $date = $this->faker->dateTimeBetween('tomorrow', '+6 weeks')->format('Y-m-d');
+        $organisationEvent2 = OrganisationEvent::factory()->create([
+            'organisation_id' => $organisation->id,
+            'slug' => 'other-slug',
+        ]);
+
+        $organisationEvent3 = OrganisationEvent::factory()->create([
+            'organisation_id' => $organisation->id,
+            'slug' => 'yet-another-slug',
+        ]);
+
         $payload = [
-            'title' => $this->faker->sentence(3),
-            'start_date' => $date,
-            'end_date' => $date,
-            'start_time' => '09:00:00',
-            'end_time' => '13:00:00',
-            'intro' => $this->faker->sentence(),
-            'description' => $this->faker->paragraph(),
-            'is_free' => false,
-            'fees_text' => $this->faker->sentence(),
-            'fees_url' => $this->faker->url(),
-            'organiser_name' => $this->faker->name(),
-            'organiser_phone' => random_uk_phone(),
-            'organiser_email' => $this->faker->safeEmail(),
-            'organiser_url' => $this->faker->url(),
-            'booking_title' => $this->faker->sentence(3),
-            'booking_summary' => $this->faker->sentence(),
-            'booking_url' => $this->faker->url(),
-            'booking_cta' => $this->faker->words(2, true),
-            'homepage' => false,
-            'is_virtual' => false,
-            'location_id' => $location->id,
+            'slug' => 'event-slug',
         ];
 
-        $response = $this->json('PUT', "/core/v1/organisation-events/{$organisationEvent->id}", $payload);
+        $response = $this->json('PUT', "/core/v1/organisation-events/{$organisationEvent2->id}", $payload);
 
         $response->assertStatus(Response::HTTP_OK);
 
-        $updateRequest = UpdateRequest::findOrFail($response->json('id'));
-        $this->assertEquals($updateRequest->data, $payload);
+        $updateRequest = UpdateRequest::find($response->json('id'));
+
+        $this->assertEquals('event-slug-1', $updateRequest->data['slug']);
 
         $this->approveUpdateRequest($updateRequest->id);
 
         // The organisation event is updated
-        $this->assertDatabaseHas((new OrganisationEvent())->getTable(), array_merge(['id' => $organisationEvent->id], $payload));
+        $this->assertDatabaseHas((new OrganisationEvent())->getTable(), ['id' => $organisationEvent2->id, 'slug' => 'event-slug-1']);
+
+        $response = $this->json('PUT', "/core/v1/organisation-events/{$organisationEvent3->id}", $payload);
+
+        $response->assertStatus(Response::HTTP_OK);
+
+        $updateRequest = UpdateRequest::find($response->json('id'));
+
+        $this->assertEquals('event-slug-2', $updateRequest->data['slug']);
+
+        $this->approveUpdateRequest($updateRequest->id);
+
+        // The organisation event is updated
+        $this->assertDatabaseHas((new OrganisationEvent())->getTable(), ['id' => $organisationEvent3->id, 'slug' => 'event-slug-2']);
     }
 
     /**
@@ -2755,7 +2848,8 @@ class OrganisationEventsTest extends TestCase
 
         $date = $this->faker->dateTimeBetween('tomorrow', '+6 weeks')->format('Y-m-d');
         $payload = [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $date,
             'end_date' => $date,
             'start_time' => '09:00:00',
@@ -2831,7 +2925,8 @@ class OrganisationEventsTest extends TestCase
 
         $date = $this->faker->dateTimeBetween('tomorrow', '+6 weeks')->format('Y-m-d');
         $payload = [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $date,
             'end_date' => $date,
             'start_time' => '09:00:00',
@@ -2941,7 +3036,8 @@ class OrganisationEventsTest extends TestCase
 
         $date = $this->faker->dateTimeBetween('tomorrow', '+6 weeks')->format('Y-m-d');
         $payload = [
-            'title' => $this->faker->sentence(3),
+            'title' => 'A New Organisation Event',
+            'slug' => 'a-new-organisation-event',
             'start_date' => $date,
             'end_date' => $date,
             'start_time' => '09:00:00',

--- a/tests/Feature/ServicesTest.php
+++ b/tests/Feature/ServicesTest.php
@@ -1238,9 +1238,31 @@ class ServicesTest extends TestCase
 
         $response->assertStatus(Response::HTTP_OK);
 
-        $updateRequest = UpdateRequest::find($response->json('id'));
+        $updateRequest1 = UpdateRequest::find($response->json('id'));
 
-        $this->assertEquals('test-slug-1', $updateRequest->data['slug']);
+        $this->assertEquals('test-slug', $updateRequest1->data['slug']);
+
+        $response = $this->json('POST', '/core/v1/services', $payload);
+
+        $response->assertStatus(Response::HTTP_OK);
+
+        $updateRequest2 = UpdateRequest::find($response->json('id'));
+
+        $this->assertEquals('test-slug', $updateRequest2->data['slug']);
+
+        $updateData = $this->approveUpdateRequest($updateRequest1->id);
+
+        $this->assertDatabaseHas('services', [
+            'id' => $updateData['updateable_id'],
+            'slug' => 'test-slug-1',
+        ]);
+
+        $updateData = $this->approveUpdateRequest($updateRequest2->id);
+
+        $this->assertDatabaseHas('services', [
+            'id' => $updateData['updateable_id'],
+            'slug' => 'test-slug-2',
+        ]);
     }
 
     /**
@@ -4600,7 +4622,14 @@ class ServicesTest extends TestCase
 
         $updateRequest = UpdateRequest::find($response->json('id'));
 
-        $this->assertEquals('test-slug-1', $updateRequest->data['slug']);
+        $this->assertEquals('test-slug', $updateRequest->data['slug']);
+
+        $this->approveUpdateRequest($updateRequest->id);
+
+        $this->assertDatabaseHas('services', [
+            'id' => $service2->id,
+            'slug' => 'test-slug-1',
+        ]);
     }
 
     /**

--- a/tests/Feature/UpdateRequestsTest.php
+++ b/tests/Feature/UpdateRequestsTest.php
@@ -1144,8 +1144,8 @@ class UpdateRequestsTest extends TestCase
             ->where('updateable_id', null)
             ->firstOrFail();
 
-        $globalAdminUser = User::factory()->create()->makeSuperAdmin();
-        Passport::actingAs($globalAdminUser);
+        $superAdminUser = User::factory()->create()->makeSuperAdmin();
+        Passport::actingAs($superAdminUser);
 
         $response = $this->json('PUT', "/core/v1/update-requests/{$updateRequest->id}/approve");
 
@@ -1153,7 +1153,7 @@ class UpdateRequestsTest extends TestCase
 
         $this->assertDatabaseHas((new UpdateRequest())->getTable(), [
             'id' => $updateRequest->id,
-            'actioning_user_id' => $globalAdminUser->id,
+            'actioning_user_id' => $superAdminUser->id,
             'approved_at' => $now,
         ]);
 

--- a/tests/Unit/Generators/UniqueSlugGeneratorTest.php
+++ b/tests/Unit/Generators/UniqueSlugGeneratorTest.php
@@ -2,10 +2,11 @@
 
 namespace Tests\Unit\Generators;
 
+use Tests\TestCase;
+use App\Models\Model;
+use Illuminate\Database\Query\Builder;
 use App\Generators\UniqueSlugGenerator;
 use Illuminate\Database\DatabaseManager;
-use Illuminate\Database\Query\Builder;
-use Tests\TestCase;
 
 class UniqueSlugGeneratorTest extends TestCase
 {
@@ -21,6 +22,9 @@ class UniqueSlugGeneratorTest extends TestCase
             ->method('where')
             ->willReturn($builderMock);
         $builderMock->expects($this->once())
+            ->method('when')
+            ->willReturn($builderMock);
+        $builderMock->expects($this->once())
             ->method('exists')
             ->willReturn(false);
 
@@ -30,8 +34,13 @@ class UniqueSlugGeneratorTest extends TestCase
             ->with('table', ['test-table'])
             ->willReturn($builderMock);
 
+        $modelMock = $this->createMock(Model::class);
+        $modelMock->expects($this->once())
+            ->method('getTable')
+            ->willReturn('test-table');
+
         $generator = new UniqueSlugGenerator($dbMock);
-        $result = $generator->generate($string, 'test-table');
+        $result = $generator->generate($string, $modelMock);
 
         $this->assertEquals($expected, $result);
     }
@@ -48,6 +57,9 @@ class UniqueSlugGeneratorTest extends TestCase
             ->method('where')
             ->willReturn($builderMock);
         $builderMock->expects($this->exactly($usedCount + 1))
+            ->method('when')
+            ->willReturn($builderMock);
+        $builderMock->expects($this->exactly($usedCount + 1))
             ->method('exists')
             ->willReturnOnConsecutiveCalls(
                 ...array_map(function ($value) use ($usedCount) {
@@ -61,8 +73,13 @@ class UniqueSlugGeneratorTest extends TestCase
             ->with('table', ['test-table'])
             ->willReturn($builderMock);
 
+        $modelMock = $this->createMock(Model::class);
+        $modelMock->expects($this->exactly($usedCount + 1))
+            ->method('getTable')
+            ->willReturn('test-table');
+
         $generator = new UniqueSlugGenerator($dbMock);
-        $result = $generator->generate($string, 'test-table');
+        $result = $generator->generate($string, $modelMock);
 
         $this->assertEquals($expected, $result);
     }


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/3347/update-slug-auto-increment-logic-to-apply-to-a-service-update-as-well-as-a-service-creation

- Refactored all entities that use a slug field to calculate the slug field when an update is applied so multiple update requests in a queue will not overwrite each other.

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
