### PR TITLE
Delete organisation taxonomy relationships when delting organisation

### DIFF
--- a/app/Observers/OrganisationObserver.php
+++ b/app/Observers/OrganisationObserver.php
@@ -39,5 +39,6 @@ class OrganisationObserver
         $organisation->userRoles->each->delete();
         $organisation->updateRequests->each->delete();
         $organisation->services->each->delete();
+        $organisation->syncTaxonomyRelationships(collect([]));
     }
 }

--- a/tests/Feature/OrganisationsTest.php
+++ b/tests/Feature/OrganisationsTest.php
@@ -1753,6 +1753,28 @@ class OrganisationsTest extends TestCase
     /**
      * @test
      */
+    public function deleteOrganisationWithTaxonomiesAsSuperAdmin200(): void
+    {
+        $organisation = Organisation::factory()->create();
+        $taxonomy = Taxonomy::factory()->create();
+        $organisation->syncTaxonomyRelationships(collect([$taxonomy]));
+        $user = User::factory()->create()->makeSuperAdmin();
+
+        Passport::actingAs($user);
+
+        $response = $this->json('DELETE', "/core/v1/organisations/{$organisation->id}");
+
+        $response->assertStatus(Response::HTTP_OK);
+        $this->assertDatabaseMissing((new Organisation())->getTable(), ['id' => $organisation->id]);
+        $this->assertDatabaseMissing((new OrganisationTaxonomy())->getTable(), [
+            'organisation_id' => $organisation->id,
+            'taxonomy_id' => $taxonomy->id,
+        ]);
+    }
+
+    /**
+     * @test
+     */
     public function audit_created_when_deleted(): void
     {
         $this->fakeEvents();


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/4470/can-t-delete-an-organisation-with-taxonomies

- Updated Observer to delete organisation taxonomy relationships when deleting an organistion

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [ ] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
