### PR TITLE
Disable service or page when action edit flag is passed to approve

### DIFF
--- a/app/Docs/Paths/UpdateRequests/UpdateRequestsApprovePath.php
+++ b/app/Docs/Paths/UpdateRequests/UpdateRequestsApprovePath.php
@@ -16,13 +16,17 @@ class UpdateRequestsApprovePath extends PathItem
     public static function create(string $objectId = null): BaseObject
     {
         return parent::create($objectId)
-            ->route('/update-requests/{update_request}/approve')
+            ->route('/update-requests/{update_request}/approve?action={action}')
             ->parameters(
                 Parameter::path()
                     ->name('update_request')
                     ->description('The ID of the update request')
                     ->required()
-                    ->schema(Schema::string()->format(Schema::FORMAT_UUID))
+                    ->schema(Schema::string()->format(Schema::FORMAT_UUID)),
+                Parameter::query()
+                    ->name('action')
+                    ->description('The follow on action after approving')
+                    ->schema(Schema::string()->enum('show', 'edit'))
             )
             ->operations(
                 ApproveUpdateRequestOperation::create()


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/3307/add-new-approve-and-edit-button-to-update-requests

- Added a flag to the update request approve endpoint to indicate if this is an 'approve' or 'approve and edit' submission
- Pages and services will be disabled if the submission is 'approve and edit'

### Development checklist

- [x] Changes have been made to the API?
  - [x] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
