### PR TITLE
Feature/sc 3396/introduce a next occurs to the service schema

### DIFF
--- a/app/Docs/Schemas/ServiceLocation/ServiceLocationSchema.php
+++ b/app/Docs/Schemas/ServiceLocation/ServiceLocationSchema.php
@@ -26,6 +26,15 @@ class ServiceLocationSchema extends Schema
                     ->items(RegularOpeningHourSchema::create()),
                 Schema::array('holiday_opening_hours')
                     ->items(HolidayOpeningHourSchema::create()),
+                Schema::object('next_occurs')
+                    ->properties(
+                        Schema::string('date')
+                            ->format(Schema::FORMAT_DATE),
+                        Schema::string('start_time')
+                            ->format('time'),
+                        Schema::string('end_time')
+                            ->format('time')
+                    ),
                 Schema::string('created_at')
                     ->format(Schema::FORMAT_DATE_TIME)
                     ->nullable(),

--- a/app/Http/Resources/ServiceLocationResource.php
+++ b/app/Http/Resources/ServiceLocationResource.php
@@ -22,6 +22,7 @@ class ServiceLocationResource extends JsonResource
             'is_open_now' => $this->isOpenNow(),
             'regular_opening_hours' => RegularOpeningHourResource::collection($this->regularOpeningHours),
             'holiday_opening_hours' => HolidayOpeningHourResource::collection($this->holidayOpeningHours),
+            'next_occurs' => $this->nextOccurs(),
             'created_at' => $this->created_at->format(CarbonImmutable::ISO8601),
             'updated_at' => $this->updated_at->format(CarbonImmutable::ISO8601),
 

--- a/app/Models/HolidayOpeningHour.php
+++ b/app/Models/HolidayOpeningHour.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Models\Mutators\HolidayOpeningHourMutators;
 use App\Models\Relationships\HolidayOpeningHourRelationships;
 use App\Models\Scopes\HolidayOpeningHourScopes;
+use App\Support\Time;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class HolidayOpeningHour extends Model
@@ -26,4 +27,20 @@ class HolidayOpeningHour extends Model
         'created_at' => 'datetime',
         'updated_at' => 'datetime',
     ];
+
+    /**
+     * Is the current time within these holiday opening hours.
+     *
+     * @return bool
+     */
+    public function isOpenNow()
+    {
+        // If closed, opening and closing time are redundant, so just return false.
+        if ($this->is_closed) {
+            return false;
+        }
+
+        // Return if the current time falls within the opening and closing time.
+        return Time::now()->between($this->opens_at, $this->closes_at);
+    }
 }

--- a/app/Models/RegularOpeningHour.php
+++ b/app/Models/RegularOpeningHour.php
@@ -5,7 +5,12 @@ namespace App\Models;
 use App\Models\Mutators\RegularOpeningHourMutators;
 use App\Models\Relationships\RegularOpeningHourRelationships;
 use App\Models\Scopes\RegularOpeningHourScopes;
+use App\Support\Time;
+use Carbon\Carbon;
+use Carbon\CarbonImmutable;
+use DateTime;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Support\Facades\Date;
 
 class RegularOpeningHour extends Model
 {
@@ -46,4 +51,110 @@ class RegularOpeningHour extends Model
     const WEEKDAY_SATURDAY = 6;
 
     const WEEKDAY_SUNDAY = 7;
+
+    /**
+     * Is the current time within this regular opening hours.
+     *
+     * @return bool
+     */
+    public function isOpenNow()
+    {
+        // Check if the current time falls within the opening hours.
+        $isOpenNow = Time::now()->between($this->opens_at, $this->closes_at);
+
+        // If not, then no further checks needed.
+        if (!$isOpenNow) {
+            return false;
+        }
+
+        // Use a different algorithm for each frequency type.
+        switch ($this->frequency) {
+            // If weekly then check that the weekday is the same as today.
+            case static::FREQUENCY_WEEKLY:
+                if (Date::today()->dayOfWeek === $this->weekday) {
+                    return true;
+                }
+                break;
+                // If monthly then check that the day of the month is the same as today.
+            case static::FREQUENCY_MONTHLY:
+                if (Date::today()->day === $this->day_of_month) {
+                    return true;
+                }
+                break;
+                // If fortnightly then check that today falls directly on a multiple of 2 weeks.
+            case static::FREQUENCY_FORTNIGHTLY:
+                if (fmod(Date::today()->diffInDays($this->starts_at) / CarbonImmutable::DAYS_PER_WEEK, 2) === 0.0) {
+                    return true;
+                }
+                break;
+                // If nth occurrence of month then check today is the same occurrence.
+            case static::FREQUENCY_NTH_OCCURRENCE_OF_MONTH:
+                $occurrence = occurrence($this->occurrence_of_month);
+                $weekday = weekday($this->weekday);
+                $month = month(Date::today()->month);
+                $year = Date::today()->year;
+                $dateString = "$occurrence $weekday of $month $year";
+                $date = Date::createFromTimestamp(strtotime($dateString));
+                if (Date::today()->equalTo($date)) {
+                    return true;
+                }
+                break;
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the next open times.
+     *
+     * @param Date $from
+     * @return DateTime
+     */
+    public function nextOpenDate(?Date $from = null): DateTime
+    {
+        $fromDate = $from ? (new Carbon($from)) : Carbon::now();
+        $fromDate->settings(['monthOverflow' => false]);
+
+        switch ($this->frequency) {
+            case static::FREQUENCY_WEEKLY:
+                $nextOccursDaysDiff = $fromDate->dayOfWeekIso > $this->weekday ? CarbonImmutable::DAYS_PER_WEEK - ($fromDate->dayOfWeekIso - $this->weekday) : $this->weekday - $fromDate->dayOfWeekIso;
+
+                return $fromDate->addDays($nextOccursDaysDiff);
+                break;
+            case static::FREQUENCY_MONTHLY:
+                if ($fromDate->day > $this->day_of_month) {
+                    $fromDate->addMonth();
+                }
+                if ($this->day_of_month > $fromDate->daysInMonth) {
+                    $fromDate->day = $fromDate->daysInMonth;
+                } else {
+                    $fromDate->day = $this->day_of_month;
+                }
+
+                return $fromDate;
+                break;
+            case static::FREQUENCY_FORTNIGHTLY:
+                $fortnightDiff = ceil($fromDate->diffInDays($this->starts_at) / (CarbonImmutable::DAYS_PER_WEEK * 2));
+
+                return (new Carbon($this->starts_at))->addWeeks($fortnightDiff * 2);
+                break;
+            case static::FREQUENCY_NTH_OCCURRENCE_OF_MONTH:
+                $occurrence = occurrence($this->occurrence_of_month);
+                $weekday = weekday($this->weekday);
+                $month = month($fromDate->month);
+                $year = $fromDate->year;
+                $dateString = "$occurrence $weekday of $month $year";
+                $openDate = Carbon::createFromTimestamp(strtotime($dateString));
+                if ($openDate->lessThan($fromDate)) {
+                    $fromDate->addMonth();
+                    $month = month($fromDate->month);
+                    $year = $fromDate->year;
+                    $dateString = "$occurrence $weekday of $month $year";
+                    $openDate = Carbon::createFromTimestamp(strtotime($dateString));
+                }
+
+                return $openDate;
+                break;
+        }
+    }
 }

--- a/app/Models/RegularOpeningHour.php
+++ b/app/Models/RegularOpeningHour.php
@@ -9,6 +9,7 @@ use App\Support\Time;
 use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use DateTime;
+use DateTimeInterface;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Support\Facades\Date;
 
@@ -107,10 +108,10 @@ class RegularOpeningHour extends Model
     /**
      * Get the next open times.
      *
-     * @param Date $from
+     * @param DateTimeInterface $from
      * @return DateTime
      */
-    public function nextOpenDate(?Date $from = null): DateTime
+    public function nextOpenDate(?DateTimeInterface $from = null): DateTime
     {
         $fromDate = $from ? (new Carbon($from)) : Carbon::now();
         $fromDate->settings(['monthOverflow' => false]);

--- a/tests/Feature/ServiceLocationsTest.php
+++ b/tests/Feature/ServiceLocationsTest.php
@@ -452,6 +452,26 @@ class ServiceLocationsTest extends TestCase
                 'end_time' => $regularOpeningHour->closes_at->toString(),
             ],
         ]);
+
+        HolidayOpeningHour::factory()->create([
+            'service_location_id' => $serviceLocation->id,
+            'is_closed' => false,
+            'starts_at' => '2024-08-02',
+            'ends_at' => '2024-08-09',
+            'opens_at' => '10:00:00',
+            'closes_at' => '16:00:00',
+        ]);
+
+        $response = $this->json('GET', "/core/v1/service-locations/{$serviceLocation->id}");
+
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertJsonFragment([
+            'next_occurs' => [
+                'date' => '2024-08-05',
+                'start_time' => '10:00:00',
+                'end_time' => '16:00:00',
+            ],
+        ]);
     }
 
     /**
@@ -482,6 +502,23 @@ class ServiceLocationsTest extends TestCase
                 'end_time' => $regularOpeningHour->closes_at->toString(),
             ],
         ]);
+
+        HolidayOpeningHour::factory()->create([
+            'service_location_id' => $serviceLocation->id,
+            'starts_at' => '2024-08-26',
+            'ends_at' => '2024-08-30',
+        ]);
+
+        $response = $this->json('GET', "/core/v1/service-locations/{$serviceLocation->id}");
+
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertJsonFragment([
+            'next_occurs' => [
+                'date' => '2024-09-28',
+                'start_time' => $regularOpeningHour->opens_at->toString(),
+                'end_time' => $regularOpeningHour->closes_at->toString(),
+            ],
+        ]);
     }
 
     /**
@@ -501,6 +538,23 @@ class ServiceLocationsTest extends TestCase
         ]);
 
         Date::setTestNow(Carbon::parse('31st July 2024'));
+
+        $response = $this->json('GET', "/core/v1/service-locations/{$serviceLocation->id}");
+
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertJsonFragment([
+            'next_occurs' => [
+                'date' => '2024-08-13',
+                'start_time' => $regularOpeningHour->opens_at->toString(),
+                'end_time' => $regularOpeningHour->closes_at->toString(),
+            ],
+        ]);
+
+        HolidayOpeningHour::factory()->create([
+            'service_location_id' => $serviceLocation->id,
+            'starts_at' => '2024-08-05',
+            'ends_at' => '2024-08-09',
+        ]);
 
         $response = $this->json('GET', "/core/v1/service-locations/{$serviceLocation->id}");
 
@@ -539,6 +593,23 @@ class ServiceLocationsTest extends TestCase
         $response->assertJsonFragment([
             'next_occurs' => [
                 'date' => '2024-08-26',
+                'start_time' => $regularOpeningHour->opens_at->toString(),
+                'end_time' => $regularOpeningHour->closes_at->toString(),
+            ],
+        ]);
+
+        HolidayOpeningHour::factory()->create([
+            'service_location_id' => $serviceLocation->id,
+            'starts_at' => '2024-08-26',
+            'ends_at' => '2024-08-30',
+        ]);
+
+        $response = $this->json('GET', "/core/v1/service-locations/{$serviceLocation->id}");
+
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertJsonFragment([
+            'next_occurs' => [
+                'date' => '2024-09-30',
                 'start_time' => $regularOpeningHour->opens_at->toString(),
                 'end_time' => $regularOpeningHour->closes_at->toString(),
             ],


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/3396/introduce-a-next-occurs-to-the-service-schema

- Added `next_occurs` property to each `ServiceLocation` on a `Service` `service_locations` property
- Each `next_occurs` property has a `date`, `start_time` and `end_time`

### Development checklist

- [x] Changes have been made to the API?
  - [x] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
