### PR TITLE
Add migration to increase size of update request message field

### DIFF
--- a/database/migrations/2024_08_01_140913_update_update_requests_increase_message_field_size.php
+++ b/database/migrations/2024_08_01_140913_update_update_requests_increase_message_field_size.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('update_requests', function (Blueprint $table) {
+            $table->string('rejection_message', 1000)->after('data')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('update_requests', function (Blueprint $table) {
+            $table->string('rejection_message', 1000)->after('data')->nullable()->change();
+        });
+    }
+};


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/4543/update-request-rejection-error

- Added migration to increase `update_requests.rejection_message` from 100 to 1000 characters

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
