### PR TITLE
Added max length validation rule for gallery images

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -131,6 +131,9 @@ SERVICE_OFFERINGS=true
 # The request rate limit per minute for the api
 API_RATE_LIMIT=300
 
+# The max number of gallery images per service
+SERVICE_MAX_GALLERY_IMAGES=5
+
 # Passport keys.
 # Once ./develop artisan passport:keys has been run
 # Copy and paste the contents of storage/oauth-private.key

--- a/app/Http/Requests/Service/StoreRequest.php
+++ b/app/Http/Requests/Service/StoreRequest.php
@@ -210,7 +210,7 @@ class StoreRequest extends FormRequest
             ])],
             'social_medias.*.url' => ['required_with:social_medias.*', 'url', 'max:255'],
 
-            'gallery_items' => ['present', 'array'],
+            'gallery_items' => ['present', 'array', 'max:' . config('local.max_gallery_images')],
             'gallery_items.*' => ['array'],
             'gallery_items.*.file_id' => [
                 'required_with:gallery_items.*',

--- a/app/Http/Requests/Service/UpdateRequest.php
+++ b/app/Http/Requests/Service/UpdateRequest.php
@@ -258,7 +258,7 @@ class UpdateRequest extends FormRequest
             ],
             'social_medias.*.url' => ['required_with:social_medias.*', 'url', 'max:255'],
 
-            'gallery_items' => ['array'],
+            'gallery_items' => ['array', 'max:' . config('local.max_gallery_images')],
             'gallery_items.*' => ['array'],
             'gallery_items.*.file_id' => [
                 'required_with:gallery_items.*',

--- a/config/local.php
+++ b/config/local.php
@@ -98,4 +98,9 @@ return [
      * Page copy character limit.
      */
     'page_copy_max_chars' => env('PAGE_COPY_MAX_CHARS', 60000),
+
+    /**
+     * Max number of gallery images per service.
+     */
+    'max_gallery_images' => env('SERVICE_MAX_GALLERY_IMAGES', 5),
 ];


### PR DESCRIPTION
### Summary

https://app.shortcut.com/connectedplaces/story/4547/enforce-a-max-limit-on-the-number-of-gallery-items-for-services

- Added `max` rule `gallery_images` array field on store service
- Added `max` rule `gallery_images` array field on update service
- Added `.env` variable `SERVICE_MAX_GALLERY_IMAGES` which defaults to 5

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
